### PR TITLE
Refactor/category/custom error #13

### DIFF
--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CategoryException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CategoryException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CategoryException extends BaseException {
+	public CategoryException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CategoryLikeException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CategoryLikeException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CategoryLikeException extends BaseException {
+	public CategoryLikeException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CategoryNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CategoryNotFoundException.java
@@ -1,10 +1,19 @@
 package com.life.jeonggiju.domain.category.exception;
 
+import java.util.UUID;
+
+import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 import com.life.jeonggiju.exception.BaseException;
 import com.life.jeonggiju.exception.ErrorCode;
 
-public class CategoryNotFoundException extends BaseException {
+public class CategoryNotFoundException extends CategoryException {
 	public CategoryNotFoundException() {
 		super(ErrorCode.CATEGORY_NOT_FOUND);
+	}
+
+	public static CategoryNotFoundException withId(UUID id) {
+		CategoryNotFoundException exception = new CategoryNotFoundException();
+		exception.addDetail("categoryId", id);
+		return exception;
 	}
 }

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentDeleteForbiddenException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentDeleteForbiddenException.java
@@ -1,0 +1,18 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CommentDeleteForbiddenException extends CommentException {
+	public CommentDeleteForbiddenException() {
+		super(ErrorCode.COMMENT_DELETE_FORBIDDEN);
+	}
+
+	public static CommentDeleteForbiddenException withIds(UUID commentId, UUID userId) {
+		CommentDeleteForbiddenException exception = new CommentDeleteForbiddenException();
+		exception.addDetail("commentId", commentId);
+		exception.addDetail("userId", userId);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CommentException extends BaseException {
+	public CommentException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentNotFoundException.java
@@ -1,0 +1,17 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CommentNotFoundException extends CommentException {
+	public CommentNotFoundException() {
+		super(ErrorCode.COMMENT_NOT_FOUND);
+	}
+
+	public static CommentNotFoundException withId(UUID id) {
+		CommentNotFoundException exception = new CommentNotFoundException();
+		exception.addDetail("commentId", id);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentUpdateForbiddenException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/CommentUpdateForbiddenException.java
@@ -1,0 +1,18 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CommentUpdateForbiddenException extends CommentException {
+	public CommentUpdateForbiddenException() {
+		super(ErrorCode.COMMENT_UPDATE_FORBIDDEN);
+	}
+
+	public static CommentUpdateForbiddenException withIds(UUID commentId, UUID userId) {
+		CommentUpdateForbiddenException exception = new CommentUpdateForbiddenException();
+		exception.addDetail("commentId", commentId);
+		exception.addDetail("userId", userId);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/DuplicateLikeException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/DuplicateLikeException.java
@@ -1,0 +1,11 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class DuplicateLikeException extends  CategoryLikeException{
+	public DuplicateLikeException() {
+		super(ErrorCode.DUPLICATE_LIKE);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/EmptyCommentContentException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/EmptyCommentContentException.java
@@ -1,0 +1,9 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class EmptyCommentContentException extends CommentException {
+	public EmptyCommentContentException() {
+		super(ErrorCode.EMPTY_COMMENT_CONTENT);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/exception/ParentCommentMismatchException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/exception/ParentCommentMismatchException.java
@@ -1,0 +1,18 @@
+package com.life.jeonggiju.domain.category.exception;
+
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class ParentCommentMismatchException extends CommentException {
+	public ParentCommentMismatchException() {
+		super(ErrorCode.PARENT_COMMENT_MISMATCH);
+	}
+
+	public static ParentCommentMismatchException withIds(UUID categoryId, UUID parentId) {
+		ParentCommentMismatchException exception = new ParentCommentMismatchException();
+		exception.addDetail("categoryId", categoryId);
+		exception.addDetail("parentId", parentId);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryLikeService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryLikeService.java
@@ -14,12 +14,14 @@ import com.life.jeonggiju.domain.category.dto.LikePersonResponse;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.entity.CategoryLike;
 import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
+import com.life.jeonggiju.domain.category.exception.DuplicateLikeException;
 import com.life.jeonggiju.domain.category.repository.CategoryLikeRepository;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
 import com.life.jeonggiju.domain.notification.dto.NotificationCreatedDto;
 import com.life.jeonggiju.domain.notification.entity.NotificationType;
 import com.life.jeonggiju.domain.notification.service.NotificationService;
 import com.life.jeonggiju.domain.user.entity.User;
+import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 import com.life.jeonggiju.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,15 +30,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CategoryLikeService {
 
+	private final NotificationService notificationService;
+
 	private final CategoryLikeRepository categoryLikeRepository;
 	private final UserRepository userRepository;
 	private final CategoryRepository categoryRepository;
 
-	private final NotificationService notificationService;
 
 	@Transactional(readOnly = true)
 	public List<LikePersonResponse> findUserEmails(UUID categoryId) {
-		Category category = categoryRepository.findById(categoryId).orElseThrow(CategoryNotFoundException::new);
+		Category category = categoryRepository.findById(categoryId).orElseThrow(()->CategoryNotFoundException.withId(categoryId));
 		List<CategoryLike> likes = category.getCategoryLikes();
 		List<LikePersonResponse> response = new ArrayList<>();
 
@@ -55,11 +58,11 @@ public class CategoryLikeService {
 	@Transactional
 	public void add(UUID userId, UUID categoryId) {
 		if (categoryLikeRepository.existsByUserIdAndCategoryId(userId, categoryId)) {
-			throw new RuntimeException("중복 좋아요 불가.");
+			throw new DuplicateLikeException();
 		}
 
-		User user = userRepository.findById(userId).orElseThrow();
-		Category category = categoryRepository.findById(categoryId).orElseThrow();
+		User user = userRepository.findById(userId).orElseThrow(()->UserNotFoundException.withUserId(userId));
+		Category category = categoryRepository.findById(categoryId).orElseThrow(()->CategoryNotFoundException.withId(categoryId));
 
 		categoryLikeRepository.save(CategoryLike.of(user, category));
 
@@ -76,8 +79,7 @@ public class CategoryLikeService {
 
 	@Transactional(readOnly = true)
 	public CheckCountCategoryResponse checkCount(UUID userId, UUID categoryId) {
-		Optional<CategoryLike> categoryLikeOpt = categoryLikeRepository.findByUserIdAndCategoryId(userId,
-			categoryId);
+		Optional<CategoryLike> categoryLikeOpt = categoryLikeRepository.findByUserIdAndCategoryId(userId, categoryId);
 		boolean isCheck = categoryLikeOpt.isPresent();
 		Integer count = categoryLikeRepository.countByCategoryId(categoryId);
 

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryService.java
@@ -18,9 +18,11 @@ import com.life.jeonggiju.domain.category.dto.SortDir;
 import com.life.jeonggiju.domain.category.dto.UpdateCategory;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.entity.CategoryLike;
+import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
 import com.life.jeonggiju.domain.category.repository.CommentRepository;
 import com.life.jeonggiju.domain.user.entity.User;
+import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 import com.life.jeonggiju.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -33,11 +35,11 @@ public class CategoryService {
 
 	private final CategoryRepository categoryRepository;
 	private final UserRepository userRepository;
-	private final CommentRepository commentRepository;
 
 	@Transactional(readOnly = true)
 	public FindCategoryResponse find(UUID categoryId) {
-		Category category = categoryRepository.findById(categoryId).orElseThrow();
+		Category category = categoryRepository.findById(categoryId).orElseThrow(() -> CategoryNotFoundException.withId(categoryId));
+
 		long likeCount = category.getCategoryLikes().size();
 		long commentCount = category.getComments().size();
 
@@ -51,7 +53,6 @@ public class CategoryService {
 			.likeCount(likeCount)
 			.commentCount(commentCount)
 			.build();
-
 	}
 
 	@Transactional(readOnly = true)
@@ -80,7 +81,7 @@ public class CategoryService {
 
 	@Transactional(readOnly = true)
 	public List<LikeEmailCategoryResponse> findEmailLikeUser(UUID categoryId) {
-		Category category = categoryRepository.findById(categoryId).orElseThrow();
+		Category category = categoryRepository.findById(categoryId).orElseThrow(() -> CategoryNotFoundException.withId(categoryId));
 
 		List<LikeEmailCategoryResponse> result = new ArrayList<>();
 		List<CategoryLike> categoryLike = category.getCategoryLikes();
@@ -91,13 +92,12 @@ public class CategoryService {
 					.email(like.getUser().getEmail())
 					.build());
 		}
-
 		return result;
 	}
 
 	@Transactional
 	public void save(UUID userId, AddCategory dto) {
-		User user = userRepository.findById(userId).orElseThrow();
+		User user = userRepository.findById(userId).orElseThrow(()-> UserNotFoundException.withUserId(userId));
 		Category category = Category.of(dto.getTitle(), dto.getDescription(), dto.getRecordType(), user,
 			dto.getVisibility());
 		categoryRepository.save(category);
@@ -105,7 +105,7 @@ public class CategoryService {
 
 	@Transactional
 	public void update(UpdateCategory dto) {
-		Category category = categoryRepository.findById(dto.getId()).orElseThrow();
+		Category category = categoryRepository.findById(dto.getId()).orElseThrow(() -> CategoryNotFoundException.withId(dto.getId()));
 		category.update(dto.getTitle(), dto.getDescription(), dto.getVisibility());
 		categoryRepository.save(category);
 	}
@@ -204,7 +204,6 @@ public class CategoryService {
 			}
 		}
 
-		String cursor = String.join("|", values);
-		return cursor;
+		return String.join("|", values);
 	}
 }

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/service/CommentService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/service/CommentService.java
@@ -13,6 +13,12 @@ import com.life.jeonggiju.domain.category.dto.FindCommentResponse;
 import com.life.jeonggiju.domain.category.dto.UpdateCommentRequest;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.entity.Comment;
+import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
+import com.life.jeonggiju.domain.category.exception.CommentDeleteForbiddenException;
+import com.life.jeonggiju.domain.category.exception.CommentNotFoundException;
+import com.life.jeonggiju.domain.category.exception.CommentUpdateForbiddenException;
+import com.life.jeonggiju.domain.category.exception.EmptyCommentContentException;
+import com.life.jeonggiju.domain.category.exception.ParentCommentMismatchException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
 import com.life.jeonggiju.domain.category.repository.CommentRepository;
 import com.life.jeonggiju.domain.notification.dto.NotificationCreatedDto;
@@ -20,6 +26,7 @@ import com.life.jeonggiju.domain.notification.entity.NotificationType;
 import com.life.jeonggiju.domain.notification.service.NotificationService;
 import com.life.jeonggiju.domain.user.dto.CreateCommentRequest;
 import com.life.jeonggiju.domain.user.entity.User;
+import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 import com.life.jeonggiju.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,7 +34,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class CommentService {
-
 	private final CommentRepository commentRepository;
 	private final CategoryRepository categoryRepository;
 	private final UserRepository userRepository;
@@ -87,11 +93,13 @@ public class CommentService {
 	@Transactional
 	public UUID createComment(CreateCommentRequest dto, UUID userId) {
 		if (dto.getComment() == null || dto.getComment().isBlank()) {
-			throw new RuntimeException("댓글 내용은 비울 수 없음");
+			throw new EmptyCommentContentException();
 		}
 
-		Category category = categoryRepository.findById(dto.getCategoryId()).orElseThrow();
-		User user = userRepository.findById(userId).orElseThrow();
+		Category category = categoryRepository.findById(dto.getCategoryId())
+			.orElseThrow(() -> CategoryNotFoundException.withId(dto.getCategoryId()));
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> UserNotFoundException.withUserId(userId));
 
 		Comment saved = commentRepository.save(
 			Comment.builder()
@@ -117,15 +125,18 @@ public class CommentService {
 	@Transactional
 	public UUID createReply(UUID categoryId, UUID parentId, UUID userId, String content) {
 		if (content == null || content.isBlank()) {
-			throw new IllegalArgumentException("댓글 내용은 비어있을 수 없습니다.");
+			throw new EmptyCommentContentException();
 		}
 
-		Category category = categoryRepository.findById(categoryId).orElseThrow();
-		User user = userRepository.findById(userId).orElseThrow();
-		Comment parent = commentRepository.findById(parentId).orElseThrow();
+		Category category = categoryRepository.findById(categoryId)
+			.orElseThrow(() -> CategoryNotFoundException.withId(categoryId));
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> UserNotFoundException.withUserId(userId));
+		Comment parent = commentRepository.findById(parentId)
+			.orElseThrow(() -> CommentNotFoundException.withId(parentId));
 
 		if (!parent.getCategory().getId().equals(categoryId)) {
-			throw new IllegalArgumentException("부모 댓글의 카테고리가 일치하지 않습니다.");
+			throw ParentCommentMismatchException.withIds(categoryId, parentId);
 		}
 
 		Comment saved = commentRepository.save(
@@ -151,15 +162,15 @@ public class CommentService {
 
 	@Transactional
 	public void delete(UUID commentId, UUID requestUserId) {
-
-		Comment comment = commentRepository.findById(commentId).orElseThrow();
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> CommentNotFoundException.withId(commentId));
 
 		UUID authorId = comment.getUser().getId();
 		UUID categoryOwnerId = comment.getCategory().getUser().getId();
 
 		boolean canDelete = authorId.equals(requestUserId) || categoryOwnerId.equals(requestUserId);
 		if (!canDelete) {
-			throw new IllegalArgumentException("삭제 권한이 없습니다.");
+			throw CommentDeleteForbiddenException.withIds(commentId, requestUserId);
 		}
 
 		commentRepository.delete(comment);
@@ -168,14 +179,14 @@ public class CommentService {
 	@Transactional
 	public void update(UpdateCommentRequest dto, UUID requestUserId) {
 		Comment comment = commentRepository.findById(dto.getCommentId())
-			.orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+			.orElseThrow(() -> CommentNotFoundException.withId(dto.getCommentId()));
 
 		if (!comment.getUser().getId().equals(requestUserId)) {
-			throw new IllegalArgumentException("수정 권한이 없습니다.");
+			throw CommentUpdateForbiddenException.withIds(dto.getCommentId(), requestUserId);
 		}
 
 		if (dto.getComment() == null || dto.getComment().isBlank()) {
-			throw new IllegalArgumentException("댓글 내용은 비어있을 수 없습니다.");
+			throw new EmptyCommentContentException();
 		}
 
 		comment.setComment(dto.getComment());

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/exception/UserException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.user.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class UserException extends BaseException {
+	public UserException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/exception/UserNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/exception/UserNotFoundException.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import com.life.jeonggiju.exception.BaseException;
 import com.life.jeonggiju.exception.ErrorCode;
 
-public class UserNotFoundException extends BaseException {
+public class UserNotFoundException extends UserException {
 
 	public UserNotFoundException() {
 		super(ErrorCode.USER_NOT_FOUND);

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/service/UserService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.life.jeonggiju.domain.user.dto.SignUpRequest;
 import com.life.jeonggiju.domain.user.dto.UpdateUserRequest;
@@ -21,6 +22,7 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 
+	@Transactional
 	public void signup(SignUpRequest dto) {
 		User user = User.builder()
 			.username(dto.getUsername())
@@ -37,6 +39,7 @@ public class UserService {
 		userRepository.save(user);
 	}
 
+	@Transactional(readOnly = true)
 	public UserFindResponse find(UUID id) {
 		User user = userRepository.findById(id).orElseThrow();
 
@@ -51,13 +54,14 @@ public class UserService {
 			.birthDay(user.getBirthDay())
 			.build();
 	}
-
+	@Transactional
 	public void update(UUID id, UpdateUserRequest dto) {
 		User user = userRepository.findById(id).orElseThrow();
 		user.update(dto.getTitle(), dto.getDescription(), dto.getNickName());
 		userRepository.save(user);
 	}
 
+	@Transactional
 	public void delete(UUID id) {
 		userRepository.deleteById(id);
 	}

--- a/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
+++ b/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
@@ -10,6 +10,14 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
 
+	DUPLICATE_LIKE(HttpStatus.CONFLICT, "중복 좋아요는 불가합니다."),
+
+	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+	EMPTY_COMMENT_CONTENT(HttpStatus.BAD_REQUEST, "댓글 내용은 비어있을 수 없습니다."),
+	PARENT_COMMENT_MISMATCH(HttpStatus.BAD_REQUEST, "부모 댓글의 카테고리가 일치하지 않습니다."),
+	COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "삭제 권한이 없습니다."),
+	COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "수정 권한이 없습니다."),
+
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
 	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다"),
 	ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "계정이 잠겨있습니다"),

--- a/spring/src/main/java/com/life/jeonggiju/exception/GlobalExceptionHandler.java
+++ b/spring/src/main/java/com/life/jeonggiju/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.life.jeonggiju.domain.user.exception.UserException;
 import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,7 +14,9 @@ import jakarta.servlet.http.HttpServletRequest;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-	@ExceptionHandler(UserNotFoundException.class)
+
+
+	@ExceptionHandler(UserException.class)
 	public ResponseEntity<ErrorResponse> handleUserException(UserNotFoundException ex){
 		ErrorResponse response = new ErrorResponse(ex);
 		return ResponseEntity

--- a/spring/src/main/java/com/life/jeonggiju/exception/GlobalExceptionHandler.java
+++ b/spring/src/main/java/com/life/jeonggiju/exception/GlobalExceptionHandler.java
@@ -1,35 +1,21 @@
 package com.life.jeonggiju.exception;
 
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import com.life.jeonggiju.domain.user.exception.UserException;
-import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-
-
-	@ExceptionHandler(UserException.class)
-	public ResponseEntity<ErrorResponse> handleUserException(UserNotFoundException ex){
-		ErrorResponse response = new ErrorResponse(ex);
-		return ResponseEntity
-			.status(ex.getErrorCode().getHttpStatus())
-			.body(response);
-	}
-
 	@ExceptionHandler(BaseException.class)
 	public ResponseEntity<ErrorResponse> handleBaseException(BaseException ex) {
 		ErrorResponse response = new ErrorResponse(ex);
 		return ResponseEntity
-				.status(ex.getErrorCode().getHttpStatus())
-				.body(response);
+			.status(ex.getErrorCode().getHttpStatus())
+			.body(response);
 	}
 
 	@ExceptionHandler(Exception.class)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/exception-refactor -> dev

### 변경 사항
- 도메인별 공통 상위 예외 클래스 추가
  - CategoryException
  - CategoryLikeException
  - CommentException
  - UserException
- 기존 RuntimeException / IllegalArgumentException / orElseThrow() 사용 구간을
  ErrorCode 기반의 명시적 커스텀 예외로 전환
- Category / Comment / Like / User 도메인 전반의 예외 구조 정리
  - CategoryNotFoundException → CategoryException 상속
  - UserNotFoundException → UserException 상속
- 댓글/좋아요/카테고리 관련 에러를 HTTP Status에 맞게 일관되게 매핑
  - DUPLICATE_LIKE → 409 CONFLICT
  - EMPTY_COMMENT_CONTENT → 400 BAD_REQUEST
  - COMMENT_NOT_FOUND → 404 NOT_FOUND
  - COMMENT_DELETE_FORBIDDEN / COMMENT_UPDATE_FORBIDDEN → 403 FORBIDDEN
- GlobalExceptionHandler에서 BaseException 기반 공통 처리로 통합

### 테스트 결과
- 기존 API 시나리오(카테고리 조회/생성/수정, 좋아요 추가, 댓글 생성/수정/삭제) 정상 동작 확인
- 예외 발생 시 ErrorCode + HTTP Status가 의도한 값으로 응답됨
- 기존 기능 동작에는 영향 없음
