### PR TITLE
[REFACTOR] 레코드 및 알림 도메인 커스텀 에러 추가  #14

### DIFF
--- a/spring/src/main/java/com/life/jeonggiju/domain/category/entity/Category.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/entity/Category.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import org.springframework.data.annotation.CreatedDate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.life.jeonggiju.domain.checkList.entity.CheckListRecord;
+import com.life.jeonggiju.domain.checkListRecord.entity.CheckListRecord;
 import com.life.jeonggiju.domain.checkRecord.entity.CheckRecord;
 import com.life.jeonggiju.domain.textRecord.entity.TextRecord;
 import com.life.jeonggiju.domain.timeRecord.entity.TimeRecord;

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/controller/CheckListController.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/controller/CheckListController.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.controller;
+package com.life.jeonggiju.domain.checkListRecord.controller;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.life.jeonggiju.domain.checkList.dto.FindCheckListAllResponse;
-import com.life.jeonggiju.domain.checkList.dto.FindCheckListResponse;
-import com.life.jeonggiju.domain.checkList.dto.SaveCheckList;
-import com.life.jeonggiju.domain.checkList.dto.UpdateCheckList;
-import com.life.jeonggiju.domain.checkList.entity.CheckListRecord;
-import com.life.jeonggiju.domain.checkList.service.CheckListService;
+import com.life.jeonggiju.domain.checkListRecord.dto.FindCheckListAllResponse;
+import com.life.jeonggiju.domain.checkListRecord.dto.FindCheckListResponse;
+import com.life.jeonggiju.domain.checkListRecord.dto.SaveCheckList;
+import com.life.jeonggiju.domain.checkListRecord.dto.UpdateCheckList;
+import com.life.jeonggiju.domain.checkListRecord.entity.CheckListRecord;
+import com.life.jeonggiju.domain.checkListRecord.service.CheckListService;
 
 import lombok.RequiredArgsConstructor;
 

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/FindCheckListAllResponse.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/FindCheckListAllResponse.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.dto;
+package com.life.jeonggiju.domain.checkListRecord.dto;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/FindCheckListResponse.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/FindCheckListResponse.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.dto;
+package com.life.jeonggiju.domain.checkListRecord.dto;
 
 import java.time.LocalDate;
 import java.util.UUID;

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/SaveCheckList.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/SaveCheckList.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.dto;
+package com.life.jeonggiju.domain.checkListRecord.dto;
 
 import java.time.LocalDate;
 import java.util.UUID;

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/UpdateCheckList.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/dto/UpdateCheckList.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.dto;
+package com.life.jeonggiju.domain.checkListRecord.dto;
 
 import java.time.LocalDate;
 import java.util.UUID;

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/entity/CheckListRecord.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/entity/CheckListRecord.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.entity;
+package com.life.jeonggiju.domain.checkListRecord.entity;
 
 import java.time.LocalDate;
 import java.util.UUID;

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/exception/CheckListRecordException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/exception/CheckListRecordException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.checkListRecord.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CheckListRecordException extends BaseException {
+	public CheckListRecordException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/exception/CheckListRecordNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/exception/CheckListRecordNotFoundException.java
@@ -1,0 +1,25 @@
+package com.life.jeonggiju.domain.checkListRecord.exception;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CheckListRecordNotFoundException extends CheckListRecordException {
+	public CheckListRecordNotFoundException() {
+		super(ErrorCode.CHECK_LIST_RECORD_NOT_FOUND);
+	}
+
+	public static CheckListRecordNotFoundException withId(UUID id) {
+		CheckListRecordNotFoundException exception = new CheckListRecordNotFoundException();
+		exception.addDetail("checkListRecordId", id);
+		return exception;
+	}
+
+	public static CheckListRecordNotFoundException withCategoryIdAndDate(UUID categoryId, LocalDate date) {
+		CheckListRecordNotFoundException exception = new CheckListRecordNotFoundException();
+		exception.addDetail("categoryId", categoryId);
+		exception.addDetail("date", date);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/repository/CheckListRepository.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/repository/CheckListRepository.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.repository;
+package com.life.jeonggiju.domain.checkListRecord.repository;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.life.jeonggiju.domain.checkList.entity.CheckListRecord;
+import com.life.jeonggiju.domain.checkListRecord.entity.CheckListRecord;
 
 public interface CheckListRepository extends JpaRepository<CheckListRecord, UUID> {
 

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/service/CheckListService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/service/CheckListService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
+import com.life.jeonggiju.domain.checkListRecord.exception.CheckListRecordNotFoundException;
 import com.life.jeonggiju.domain.checkListRecord.dto.FindCheckListAllResponse;
 import com.life.jeonggiju.domain.checkListRecord.dto.FindCheckListResponse;
 import com.life.jeonggiju.domain.checkListRecord.dto.SaveCheckList;
@@ -29,7 +30,8 @@ public class CheckListService {
 	private final CategoryRepository categoryRepository;
 
 	public FindCheckListResponse find(UUID checkId) {
-		CheckListRecord checkListRecord = checkListRepository.findById(checkId).orElseThrow();
+		CheckListRecord checkListRecord = checkListRepository.findById(checkId)
+			.orElseThrow(() -> CheckListRecordNotFoundException.withId(checkId));
 		return FindCheckListResponse.builder().id(checkListRecord.getId()).success(checkListRecord.isSuccess()).date(
 			checkListRecord.getDate()).build();
 	}
@@ -60,12 +62,14 @@ public class CheckListService {
 	}
 
 	public List<CheckListRecord> findByDate(UUID categoryId, LocalDate date) {
-		return checkListRepository.findByCategoryIdAndDate(categoryId, date).orElseThrow();
+		return checkListRepository.findByCategoryIdAndDate(categoryId, date)
+			.orElseThrow(() -> CheckListRecordNotFoundException.withCategoryIdAndDate(categoryId, date));
 	}
 
 	@Transactional
 	public void save(SaveCheckList dto) {
-		Category category = categoryRepository.findById(dto.getCategoryId()).orElseThrow();
+		Category category = categoryRepository.findById(dto.getCategoryId())
+			.orElseThrow(() -> CategoryNotFoundException.withId(dto.getCategoryId()));
 		CheckListRecord checkListRecord = CheckListRecord.of(category, dto.getTodo(), dto.isSuccess(), dto.getDate());
 		checkListRepository.save(checkListRecord);
 	}
@@ -73,7 +77,8 @@ public class CheckListService {
 	@Transactional
 	public void update(UpdateCheckList dto) {
 		UUID id = dto.getId();
-		CheckListRecord checkListRecord = checkListRepository.findById(id).orElseThrow();
+		CheckListRecord checkListRecord = checkListRepository.findById(id)
+			.orElseThrow(() -> CheckListRecordNotFoundException.withId(id));
 		checkListRecord.update(dto.getTodo(), dto.isSuccess(), dto.getDate());
 		checkListRepository.save(checkListRecord);
 	}

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/service/CheckListService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkListRecord/service/CheckListService.java
@@ -1,4 +1,4 @@
-package com.life.jeonggiju.domain.checkList.service;
+package com.life.jeonggiju.domain.checkListRecord.service;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -11,12 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
-import com.life.jeonggiju.domain.checkList.dto.FindCheckListAllResponse;
-import com.life.jeonggiju.domain.checkList.dto.FindCheckListResponse;
-import com.life.jeonggiju.domain.checkList.dto.SaveCheckList;
-import com.life.jeonggiju.domain.checkList.dto.UpdateCheckList;
-import com.life.jeonggiju.domain.checkList.entity.CheckListRecord;
-import com.life.jeonggiju.domain.checkList.repository.CheckListRepository;
+import com.life.jeonggiju.domain.checkListRecord.dto.FindCheckListAllResponse;
+import com.life.jeonggiju.domain.checkListRecord.dto.FindCheckListResponse;
+import com.life.jeonggiju.domain.checkListRecord.dto.SaveCheckList;
+import com.life.jeonggiju.domain.checkListRecord.dto.UpdateCheckList;
+import com.life.jeonggiju.domain.checkListRecord.entity.CheckListRecord;
+import com.life.jeonggiju.domain.checkListRecord.repository.CheckListRepository;
 import com.life.jeonggiju.domain.user.entity.User;
 
 import lombok.RequiredArgsConstructor;

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkRecord/exception/CheckRecordException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkRecord/exception/CheckRecordException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.checkRecord.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CheckRecordException extends BaseException {
+	public CheckRecordException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkRecord/exception/CheckRecordNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkRecord/exception/CheckRecordNotFoundException.java
@@ -1,0 +1,25 @@
+package com.life.jeonggiju.domain.checkRecord.exception;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class CheckRecordNotFoundException extends CheckRecordException {
+	public CheckRecordNotFoundException() {
+		super(ErrorCode.CHECK_RECORD_NOT_FOUND);
+	}
+
+	public static CheckRecordNotFoundException withId(UUID id) {
+		CheckRecordNotFoundException exception = new CheckRecordNotFoundException();
+		exception.addDetail("checkRecordId", id);
+		return exception;
+	}
+
+	public static CheckRecordNotFoundException withCategoryIdAndDate(UUID categoryId, LocalDate date) {
+		CheckRecordNotFoundException exception = new CheckRecordNotFoundException();
+		exception.addDetail("categoryId", categoryId);
+		exception.addDetail("date", date);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/checkRecord/service/CheckService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/checkRecord/service/CheckService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
+import com.life.jeonggiju.domain.checkRecord.exception.CheckRecordNotFoundException;
 import com.life.jeonggiju.domain.checkRecord.dto.FindCheckAllResponse;
 import com.life.jeonggiju.domain.checkRecord.dto.FindCheckResponse;
 import com.life.jeonggiju.domain.checkRecord.dto.SaveCheck;
@@ -29,7 +30,8 @@ public class CheckService {
 	private final CategoryRepository categoryRepository;
 
 	public FindCheckResponse find(UUID checkId) {
-		CheckRecord checkRecord = checkRepository.findById(checkId).orElseThrow();
+		CheckRecord checkRecord = checkRepository.findById(checkId)
+			.orElseThrow(() -> CheckRecordNotFoundException.withId(checkId));
 		return FindCheckResponse.builder()
 			.id(checkRecord.getId())
 			.success(checkRecord.isSuccess())
@@ -59,7 +61,8 @@ public class CheckService {
 	}
 
 	public FindCheckResponse findByDate(UUID categoryId, LocalDate date) {
-		CheckRecord checkRecord = checkRepository.findByCategoryIdAndDate(categoryId, date).orElseThrow();
+		CheckRecord checkRecord = checkRepository.findByCategoryIdAndDate(categoryId, date)
+			.orElseThrow(() -> CheckRecordNotFoundException.withCategoryIdAndDate(categoryId, date));
 		return FindCheckResponse.builder()
 			.id(checkRecord.getId())
 			.date(checkRecord.getDate())
@@ -69,7 +72,8 @@ public class CheckService {
 
 	@Transactional
 	public void save(SaveCheck dto) {
-		Category category = categoryRepository.findById(dto.getCategoryId()).orElseThrow();
+		Category category = categoryRepository.findById(dto.getCategoryId())
+			.orElseThrow(() -> CategoryNotFoundException.withId(dto.getCategoryId()));
 		CheckRecord checkRecord = CheckRecord.of(category, dto.isSuccess(), dto.getDate());
 		checkRepository.save(checkRecord);
 	}
@@ -77,7 +81,8 @@ public class CheckService {
 	@Transactional
 	public void update(UpdateCheck dto) {
 		UUID id = dto.getId();
-		CheckRecord checkRecord = checkRepository.findById(id).orElseThrow();
+		CheckRecord checkRecord = checkRepository.findById(id)
+			.orElseThrow(() -> CheckRecordNotFoundException.withId(id));
 		checkRecord.update(dto.isSuccess(), dto.getDate());
 		checkRepository.save(checkRecord);
 	}

--- a/spring/src/main/java/com/life/jeonggiju/domain/notification/exception/NotificationException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/notification/exception/NotificationException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.notification.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class NotificationException extends BaseException {
+	public NotificationException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/notification/exception/NotificationNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,17 @@
+package com.life.jeonggiju.domain.notification.exception;
+
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class NotificationNotFoundException extends NotificationException {
+	public NotificationNotFoundException() {
+		super(ErrorCode.NOTIFICATION_NOT_FOUND);
+	}
+
+	public static NotificationNotFoundException withId(UUID id) {
+		NotificationNotFoundException exception = new NotificationNotFoundException();
+		exception.addDetail("notificationId", id);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/notification/listener/NotificationEventListener.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/notification/listener/NotificationEventListener.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import com.life.jeonggiju.domain.notification.dto.NotificationPayload;
 import com.life.jeonggiju.domain.notification.entity.Notification;
 import com.life.jeonggiju.domain.notification.event.NotificationCreatedEvent;
+import com.life.jeonggiju.domain.notification.exception.NotificationNotFoundException;
 import com.life.jeonggiju.domain.notification.repository.NotificationRepository;
 import com.life.jeonggiju.sse.service.SseService;
 
@@ -21,7 +22,8 @@ public class NotificationEventListener {
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void listen(NotificationCreatedEvent event) {
-		Notification notification = notificationRepository.findById(event.getId()).orElseThrow();
+		Notification notification = notificationRepository.findById(event.getId())
+			.orElseThrow(() -> NotificationNotFoundException.withId(event.getId()));
 
 		NotificationPayload payload = NotificationPayload.builder()
 			.id(notification.getId())

--- a/spring/src/main/java/com/life/jeonggiju/domain/notification/service/NotificationService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/notification/service/NotificationService.java
@@ -15,6 +15,7 @@ import com.life.jeonggiju.domain.notification.entity.Notification;
 import com.life.jeonggiju.domain.notification.event.NotificationCreatedEvent;
 import com.life.jeonggiju.domain.notification.repository.NotificationRepository;
 import com.life.jeonggiju.domain.user.entity.User;
+import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 import com.life.jeonggiju.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -45,8 +46,10 @@ public class NotificationService {
 
 	@Transactional
 	public void notify(NotificationCreatedDto dto) {
-		User receiver = userRepository.findById(dto.getReceiverId()).orElseThrow();
-		User sender = userRepository.findById(dto.getSenderId()).orElseThrow();
+		User receiver = userRepository.findById(dto.getReceiverId())
+			.orElseThrow(() -> UserNotFoundException.withUserId(dto.getReceiverId()));
+		User sender = userRepository.findById(dto.getSenderId())
+			.orElseThrow(() -> UserNotFoundException.withUserId(dto.getSenderId()));
 
 		Notification notification = Notification.builder()
 			.receiver(receiver)

--- a/spring/src/main/java/com/life/jeonggiju/domain/numberRecord/exception/NumberRecordException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/numberRecord/exception/NumberRecordException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.numberRecord.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class NumberRecordException extends BaseException {
+	public NumberRecordException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/numberRecord/exception/NumberRecordNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/numberRecord/exception/NumberRecordNotFoundException.java
@@ -1,0 +1,25 @@
+package com.life.jeonggiju.domain.numberRecord.exception;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class NumberRecordNotFoundException extends NumberRecordException {
+	public NumberRecordNotFoundException() {
+		super(ErrorCode.NUMBER_RECORD_NOT_FOUND);
+	}
+
+	public static NumberRecordNotFoundException withId(UUID id) {
+		NumberRecordNotFoundException exception = new NumberRecordNotFoundException();
+		exception.addDetail("numberRecordId", id);
+		return exception;
+	}
+
+	public static NumberRecordNotFoundException withCategoryIdAndDate(UUID categoryId, LocalDate date) {
+		NumberRecordNotFoundException exception = new NumberRecordNotFoundException();
+		exception.addDetail("categoryId", categoryId);
+		exception.addDetail("date", date);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/numberRecord/service/NumberService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/numberRecord/service/NumberService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
+import com.life.jeonggiju.domain.numberRecord.exception.NumberRecordNotFoundException;
 import com.life.jeonggiju.domain.numberRecord.dto.FindNumberAllResponse;
 import com.life.jeonggiju.domain.numberRecord.dto.FindNumberResponse;
 import com.life.jeonggiju.domain.numberRecord.dto.SaveNumber;
@@ -29,7 +30,8 @@ public class NumberService {
 	private final CategoryRepository categoryRepository;
 
 	public FindNumberResponse find(UUID numberId) {
-		NumberRecord numberRecord = numberRepository.findById(numberId).orElseThrow();
+		NumberRecord numberRecord = numberRepository.findById(numberId)
+			.orElseThrow(() -> NumberRecordNotFoundException.withId(numberId));
 		return FindNumberResponse.builder()
 			.id(numberRecord.getId())
 			.number(numberRecord.getNumber())
@@ -58,7 +60,8 @@ public class NumberService {
 	}
 
 	public FindNumberResponse findByDate(UUID categoryId, LocalDate date) {
-		NumberRecord numberRecord = numberRepository.findByCategoryIdAndDate(categoryId, date).orElseThrow();
+		NumberRecord numberRecord = numberRepository.findByCategoryIdAndDate(categoryId, date)
+			.orElseThrow(() -> NumberRecordNotFoundException.withCategoryIdAndDate(categoryId, date));
 		return FindNumberResponse.builder()
 			.id(numberRecord.getId())
 			.date(numberRecord.getDate())
@@ -68,7 +71,8 @@ public class NumberService {
 	@Transactional
 	public void save(SaveNumber dto) {
 		UUID id = dto.getCategoryId();
-		Category category = categoryRepository.findById(id).orElseThrow();
+		Category category = categoryRepository.findById(id)
+			.orElseThrow(() -> CategoryNotFoundException.withId(id));
 		NumberRecord numberRecord = NumberRecord.of(category, dto.getNumber(), dto.getDate());
 		numberRepository.save(numberRecord);
 	}
@@ -76,7 +80,8 @@ public class NumberService {
 	@Transactional
 	public void update(UpdateNumber dto) {
 		UUID id = dto.getId();
-		NumberRecord NumberRecord = numberRepository.findById(id).orElseThrow();
+		NumberRecord NumberRecord = numberRepository.findById(id)
+			.orElseThrow(() -> NumberRecordNotFoundException.withId(id));
 		NumberRecord.update(dto.getNumber(), dto.getDate());
 		numberRepository.save(NumberRecord);
 	}

--- a/spring/src/main/java/com/life/jeonggiju/domain/textRecord/exception/TextRecordException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/textRecord/exception/TextRecordException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.textRecord.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class TextRecordException extends BaseException {
+	public TextRecordException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/textRecord/exception/TextRecordNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/textRecord/exception/TextRecordNotFoundException.java
@@ -1,0 +1,25 @@
+package com.life.jeonggiju.domain.textRecord.exception;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class TextRecordNotFoundException extends TextRecordException {
+	public TextRecordNotFoundException() {
+		super(ErrorCode.TEXT_RECORD_NOT_FOUND);
+	}
+
+	public static TextRecordNotFoundException withId(UUID id) {
+		TextRecordNotFoundException exception = new TextRecordNotFoundException();
+		exception.addDetail("textRecordId", id);
+		return exception;
+	}
+
+	public static TextRecordNotFoundException withCategoryIdAndDate(UUID categoryId, LocalDate date) {
+		TextRecordNotFoundException exception = new TextRecordNotFoundException();
+		exception.addDetail("categoryId", categoryId);
+		exception.addDetail("date", date);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/textRecord/service/TextService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/textRecord/service/TextService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
+import com.life.jeonggiju.domain.textRecord.exception.TextRecordNotFoundException;
 import com.life.jeonggiju.domain.textRecord.dto.FindTextAllResponse;
 import com.life.jeonggiju.domain.textRecord.dto.FindTextResponse;
 import com.life.jeonggiju.domain.textRecord.dto.SaveText;
@@ -31,7 +32,8 @@ public class TextService {
 	private final TextRepository textRepository;
 
 	public FindTextResponse find(UUID textId) {
-		TextRecord textRecord = textRepository.findById(textId).orElseThrow();
+		TextRecord textRecord = textRepository.findById(textId)
+			.orElseThrow(() -> TextRecordNotFoundException.withId(textId));
 		FindTextResponse response = FindTextResponse.builder()
 			.id(textRecord.getId())
 			.title(textRecord.getTitle())
@@ -41,7 +43,8 @@ public class TextService {
 	}
 
 	public List<FindTextResponse> findByDate(UUID categoryId, LocalDate date) {
-		List<TextRecord> textRecords = textRepository.findByCategoryIdAndDate(categoryId, date).orElseThrow();
+		List<TextRecord> textRecords = textRepository.findByCategoryIdAndDate(categoryId, date)
+			.orElseThrow(() -> TextRecordNotFoundException.withCategoryIdAndDate(categoryId, date));
 		List<FindTextResponse> result = new ArrayList();
 		for (TextRecord textRecord : textRecords) {
 			result.add(FindTextResponse.builder()
@@ -79,7 +82,8 @@ public class TextService {
 	@Transactional
 	public void save(SaveText dto) {
 		UUID categoryId = dto.getCategoryId();
-		Category category = categoryRepository.findById(categoryId).orElseThrow();
+		Category category = categoryRepository.findById(categoryId)
+			.orElseThrow(() -> CategoryNotFoundException.withId(categoryId));
 		TextRecord textRecord = TextRecord.of(category, dto.getTitle(), dto.getText(), dto.getDate());
 		textRepository.save(textRecord);
 	}
@@ -87,7 +91,8 @@ public class TextService {
 	@Transactional
 	public void update(UpdateText dto) {
 		UUID id = dto.getId();
-		TextRecord textRecord = textRepository.findById(id).orElseThrow();
+		TextRecord textRecord = textRepository.findById(id)
+			.orElseThrow(() -> TextRecordNotFoundException.withId(id));
 		textRecord.update(dto.getTitle(), dto.getText(), dto.getDate());
 		textRepository.save(textRecord);
 	}

--- a/spring/src/main/java/com/life/jeonggiju/domain/timeRecord/exception/TimeRecordException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/timeRecord/exception/TimeRecordException.java
@@ -1,0 +1,10 @@
+package com.life.jeonggiju.domain.timeRecord.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class TimeRecordException extends BaseException {
+	public TimeRecordException(ErrorCode code) {
+		super(code);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/timeRecord/exception/TimeRecordNotFoundException.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/timeRecord/exception/TimeRecordNotFoundException.java
@@ -1,0 +1,25 @@
+package com.life.jeonggiju.domain.timeRecord.exception;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class TimeRecordNotFoundException extends TimeRecordException {
+	public TimeRecordNotFoundException() {
+		super(ErrorCode.TIME_RECORD_NOT_FOUND);
+	}
+
+	public static TimeRecordNotFoundException withId(UUID id) {
+		TimeRecordNotFoundException exception = new TimeRecordNotFoundException();
+		exception.addDetail("timeRecordId", id);
+		return exception;
+	}
+
+	public static TimeRecordNotFoundException withCategoryIdAndDate(UUID categoryId, LocalDate date) {
+		TimeRecordNotFoundException exception = new TimeRecordNotFoundException();
+		exception.addDetail("categoryId", categoryId);
+		exception.addDetail("date", date);
+		return exception;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/timeRecord/service/TimeService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/timeRecord/service/TimeService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.life.jeonggiju.domain.category.entity.Category;
 import com.life.jeonggiju.domain.category.exception.CategoryNotFoundException;
 import com.life.jeonggiju.domain.category.repository.CategoryRepository;
+import com.life.jeonggiju.domain.timeRecord.exception.TimeRecordNotFoundException;
 import com.life.jeonggiju.domain.timeRecord.dto.FindTimeAllResponse;
 import com.life.jeonggiju.domain.timeRecord.dto.FindTimeResponse;
 import com.life.jeonggiju.domain.timeRecord.dto.SaveTime;
@@ -29,7 +30,8 @@ public class TimeService {
 	private final CategoryRepository categoryRepository;
 
 	public FindTimeResponse find(UUID timeId) {
-		TimeRecord timeRecord = timeRepository.findById(timeId).orElseThrow();
+		TimeRecord timeRecord = timeRepository.findById(timeId)
+			.orElseThrow(() -> TimeRecordNotFoundException.withId(timeId));
 		return FindTimeResponse.builder()
 			.id(timeRecord.getId())
 			.time(timeRecord.getTime())
@@ -59,7 +61,8 @@ public class TimeService {
 	}
 
 	public FindTimeResponse findByDate(UUID categoryId, LocalDate date) {
-		TimeRecord timeRecord = timeRepository.findByCategoryIdAndDate(categoryId, date).orElseThrow();
+		TimeRecord timeRecord = timeRepository.findByCategoryIdAndDate(categoryId, date)
+			.orElseThrow(() -> TimeRecordNotFoundException.withCategoryIdAndDate(categoryId, date));
 		return FindTimeResponse.builder()
 			.id(timeRecord.getId())
 			.time(timeRecord.getTime())
@@ -70,7 +73,8 @@ public class TimeService {
 	@Transactional
 	public void save(SaveTime dto) {
 		UUID id = dto.getCategoryId();
-		Category category = categoryRepository.findById(id).orElseThrow();
+		Category category = categoryRepository.findById(id)
+			.orElseThrow(() -> CategoryNotFoundException.withId(id));
 		TimeRecord timeRecord = TimeRecord.of(category, dto.getTime(), dto.getDate());
 		timeRepository.save(timeRecord);
 	}
@@ -78,7 +82,8 @@ public class TimeService {
 	@Transactional
 	public void update(UpdateTime dto) {
 		UUID id = dto.getId();
-		TimeRecord timeRecord = timeRepository.findById(id).orElseThrow();
+		TimeRecord timeRecord = timeRepository.findById(id)
+			.orElseThrow(() -> TimeRecordNotFoundException.withId(id));
 		timeRecord.update(dto.getTime(), dto.getDate());
 		timeRepository.save(timeRecord);
 	}

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/service/UserService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.life.jeonggiju.domain.user.dto.UpdateUserRequest;
 import com.life.jeonggiju.domain.user.dto.UserFindResponse;
 import com.life.jeonggiju.domain.user.entity.Authority;
 import com.life.jeonggiju.domain.user.entity.User;
+import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 import com.life.jeonggiju.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -41,7 +42,8 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public UserFindResponse find(UUID id) {
-		User user = userRepository.findById(id).orElseThrow();
+		User user = userRepository.findById(id)
+			.orElseThrow(() -> UserNotFoundException.withUserId(id));
 
 		return UserFindResponse.builder()
 			.username(user.getUsername())
@@ -56,7 +58,8 @@ public class UserService {
 	}
 	@Transactional
 	public void update(UUID id, UpdateUserRequest dto) {
-		User user = userRepository.findById(id).orElseThrow();
+		User user = userRepository.findById(id)
+			.orElseThrow(() -> UserNotFoundException.withUserId(id));
 		user.update(dto.getTitle(), dto.getDescription(), dto.getNickName());
 		userRepository.save(user);
 	}

--- a/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
+++ b/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
 	CHECK_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "체크 기록을 찾을 수 없습니다."),
 	CHECK_LIST_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "체크리스트 기록을 찾을 수 없습니다."),
 
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
+
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
 	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다"),
 	ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "계정이 잠겨있습니다"),

--- a/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
+++ b/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
@@ -18,6 +18,12 @@ public enum ErrorCode {
 	COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "삭제 권한이 없습니다."),
 	COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "수정 권한이 없습니다."),
 
+	NUMBER_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "숫자 기록을 찾을 수 없습니다."),
+	TEXT_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "텍스트 기록을 찾을 수 없습니다."),
+	TIME_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "시간 기록을 찾을 수 없습니다."),
+	CHECK_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "체크 기록을 찾을 수 없습니다."),
+	CHECK_LIST_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "체크리스트 기록을 찾을 수 없습니다."),
+
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
 	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다"),
 	ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "계정이 잠겨있습니다"),


### PR DESCRIPTION
### 추가 변경 사항 (Check / Record 도메인 리팩토링)
- checkList → checkListRecord 패키지 명 및 도메인 명확화
  - controller / dto / entity / repository / service 전반 이동
  - import 경로 및 package 선언 일괄 수정
- CheckListRecord, CheckRecord, NumberRecord, TextRecord, TimeRecord 도메인에
  공통 상위 예외(BaseException 상속) 추가
  - CheckListRecordException
  - CheckRecordException
  - NumberRecordException
  - TextRecordException
  - TimeRecordException
  - NotificationException
- 각 Record 도메인별 NotFound 예외 정의 및 적용
  - CHECK_LIST_RECORD_NOT_FOUND
  - CHECK_RECORD_NOT_FOUND
  - NUMBER_RECORD_NOT_FOUND
  - TEXT_RECORD_NOT_FOUND
  - TIME_RECORD_NOT_FOUND
  - NOTIFICATION_NOT_FOUND
- 모든 Service 레이어에서
  - orElseThrow() → 의미 있는 도메인 예외로 교체
  - 날짜 + 카테고리 조회 실패 케이스까지 명확히 분리
- Notification 처리 로직에서도 User / Notification 조회 실패 시
  명시적인 도메인 예외 사용

### 변경 의도
- Record 계열 도메인의 책임과 패키지 구조를 명확히 분리
- RuntimeException / IllegalArgumentException 제거
- 모든 조회 실패 케이스를 ErrorCode + HTTP Status로 일관되게 관리
- GlobalExceptionHandler에서 공통 BaseException 처리 흐름 유지

### 테스트 결과
- 체크 / 체크리스트 / 숫자 / 텍스트 / 시간 기록 CRUD 정상 동작
- 존재하지 않는 리소스 접근 시
  - 404 NOT_FOUND + 도메인별 ErrorCode 반환 확인
- 기존 API 시그니처 및 응답 포맷 변경 없음
