### PR TITLE
refactor(category): 공개 카테고리 DTO 확장 및 QueryDSL 매핑 수정

### DIFF
--- a/spring/src/main/java/com/life/jeonggiju/domain/category/dto/CategorySummaryDto.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/dto/CategorySummaryDto.java
@@ -22,6 +22,7 @@ public class CategorySummaryDto {
 	private String authorNickname;
 	private String authorTitle;
 	private String authorDesc;
+	private String authorEmail;
 	private RecordType type;
 	private boolean hasLike;
 	private long likeCount;

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/dto/CategorySummaryDto.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/dto/CategorySummaryDto.java
@@ -20,6 +20,8 @@ public class CategorySummaryDto {
 	private String categoryDesc;
 	private UUID authorId;
 	private String authorNickname;
+	private String authorTitle;
+	private String authorDesc;
 	private RecordType type;
 	private boolean hasLike;
 	private long likeCount;

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/dto/PublicCategorySummaryResponse.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/dto/PublicCategorySummaryResponse.java
@@ -35,6 +35,7 @@ public class PublicCategorySummaryResponse {
 		long likeCount;
 
 		String authorNickname;
+		String authorEmail;
 		String authorTitle;
 		String authorDesc;
 	}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/dto/PublicCategorySummaryResponse.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/dto/PublicCategorySummaryResponse.java
@@ -28,11 +28,14 @@ public class PublicCategorySummaryResponse {
 		UUID categoryId;
 		String categoryTitle;
 		String categoryDesc;
-		String authorNickname;
 		RecordType type;
 		boolean hasLike;
 		boolean isMyCategory;
 		long commentCount;
 		long likeCount;
+
+		String authorNickname;
+		String authorTitle;
+		String authorDesc;
 	}
 }

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/repository/CategoryRepositoryImpl.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/repository/CategoryRepositoryImpl.java
@@ -86,6 +86,7 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 				user.nickname,
 				user.title,
 				user.description,
+				user.email,
 				category.recordType,
 				userLikeExpression,
 				likeCountExpr,
@@ -132,11 +133,12 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 				.authorNickname(tuple.get(4, String.class))
 				.authorTitle(tuple.get(5, String.class))
 				.authorDesc(tuple.get(6, String.class))
-				.type(tuple.get(7, RecordType.class))
-				.hasLike(Boolean.TRUE.equals(tuple.get(8, Boolean.class)))
-				.likeCount(tuple.get(9, Long.class) != null ? tuple.get(9, Long.class) : 0L)
-				.commentCount(tuple.get(10, Long.class) != null ? tuple.get(10, Long.class) : 0L)
-				.createdAt(tuple.get(11, Instant.class))
+				.authorEmail(tuple.get(7, String.class))
+				.type(tuple.get(8, RecordType.class))
+				.hasLike(Boolean.TRUE.equals(tuple.get(9, Boolean.class)))
+				.likeCount(tuple.get(10, Long.class) != null ? tuple.get(10, Long.class) : 0L)
+				.commentCount(tuple.get(11, Long.class) != null ? tuple.get(11, Long.class) : 0L)
+				.createdAt(tuple.get(12, Instant.class))
 				.build())
 			.collect(Collectors.toList());
 	}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/repository/CategoryRepositoryImpl.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/repository/CategoryRepositoryImpl.java
@@ -83,7 +83,9 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 				category.title,
 				category.description,
 				user.id,
-				user.username,
+				user.nickname,
+				user.title,
+				user.description,
 				category.recordType,
 				userLikeExpression,
 				likeCountExpr,
@@ -98,7 +100,7 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 			String searchTerm = search.trim();
 			BooleanExpression searchCondition = category.title.containsIgnoreCase(searchTerm)
 				.or(category.description.containsIgnoreCase(searchTerm))
-				.or(user.username.containsIgnoreCase(searchTerm));
+				.or(user.nickname.containsIgnoreCase(searchTerm));
 			query.where(searchCondition);
 		}
 
@@ -128,11 +130,13 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 				.categoryDesc(tuple.get(2, String.class))
 				.authorId(tuple.get(3, UUID.class))
 				.authorNickname(tuple.get(4, String.class))
-				.type(tuple.get(5, RecordType.class))
-				.hasLike(Boolean.TRUE.equals(tuple.get(6, Boolean.class)))
-				.likeCount(tuple.get(7, Long.class) != null ? tuple.get(7, Long.class) : 0L)
-				.commentCount(tuple.get(8, Long.class) != null ? tuple.get(8, Long.class) : 0L)
-				.createdAt(tuple.get(9, Instant.class))
+				.authorTitle(tuple.get(5, String.class))
+				.authorDesc(tuple.get(6, String.class))
+				.type(tuple.get(7, RecordType.class))
+				.hasLike(Boolean.TRUE.equals(tuple.get(8, Boolean.class)))
+				.likeCount(tuple.get(9, Long.class) != null ? tuple.get(9, Long.class) : 0L)
+				.commentCount(tuple.get(10, Long.class) != null ? tuple.get(10, Long.class) : 0L)
+				.createdAt(tuple.get(11, Instant.class))
 				.build())
 			.collect(Collectors.toList());
 	}
@@ -152,7 +156,7 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 			String searchTerm = search.trim();
 			BooleanExpression searchCondition = category.title.containsIgnoreCase(searchTerm)
 				.or(category.description.containsIgnoreCase(searchTerm))
-				.or(user.username.containsIgnoreCase(searchTerm));
+				.or(user.nickname.containsIgnoreCase(searchTerm));
 			query.where(searchCondition);
 		}
 
@@ -269,7 +273,7 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 			case createdAt:
 				return category.createdAt.eq(Instant.parse(value));
 			case authorNickname:
-				return user.username.eq(value);
+				return user.nickname.eq(value);
 			default:
 				return null;
 		}
@@ -299,7 +303,7 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 				Instant instant = Instant.parse(value);
 				return isAsc ? category.createdAt.gt(instant) : category.createdAt.lt(instant);
 			case authorNickname:
-				return isAsc ? user.username.gt(value) : user.username.lt(value);
+				return isAsc ? user.nickname.gt(value) : user.nickname.lt(value);
 			default:
 				return null;
 		}
@@ -357,7 +361,7 @@ public class CategoryRepositoryImpl implements CategoryRepositoryQueryDsl {
 			case createdAt:
 				return new OrderSpecifier<>(order, category.createdAt);
 			case authorNickname:
-				return new OrderSpecifier<>(order, user.username);
+				return new OrderSpecifier<>(order, user.nickname);
 			default:
 				return null;
 		}

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryService.java
@@ -154,6 +154,7 @@ public class CategoryService {
 				.categoryTitle(category.getCategoryTitle())
 				.categoryDesc(category.getCategoryDesc())
 				.authorNickname(category.getAuthorNickname())
+				.authorEmail(category.getAuthorEmail())
 				.authorTitle(category.getAuthorTitle())
 				.authorDesc(category.getAuthorDesc())
 				.type(category.getType())

--- a/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/category/service/CategoryService.java
@@ -154,6 +154,8 @@ public class CategoryService {
 				.categoryTitle(category.getCategoryTitle())
 				.categoryDesc(category.getCategoryDesc())
 				.authorNickname(category.getAuthorNickname())
+				.authorTitle(category.getAuthorTitle())
+				.authorDesc(category.getAuthorDesc())
 				.type(category.getType())
 				.hasLike(category.isHasLike())
 				.isMyCategory(userId != null && userId.equals(category.getAuthorId()))

--- a/spring/src/main/resources/application-local.yml
+++ b/spring/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
 logging:
   level:

--- a/spring/src/main/resources/sql/적당한_데이터.sql
+++ b/spring/src/main/resources/sql/적당한_데이터.sql
@@ -24,7 +24,7 @@ CREATE TEMP TABLE tmp_categories (id UUID PRIMARY KEY, record_type TEXT NOT NULL
 -- 1) users 10명
 -- =========================================================
 WITH ins AS (
-INSERT INTO users (id, authority, birth_day, birth_month, birth_year, description, email, password, title, username)
+INSERT INTO users (id, authority, birth_day, birth_month, birth_year, description, email, password, title, username, nickname)
 SELECT
     gen_random_uuid(),
     1,
@@ -35,7 +35,8 @@ SELECT
     'user' || lpad(gs::text, 2, '0') || '@example.com',
     'pass1234',
     'USER',
-    'user' || lpad(gs::text, 2, '0')
+    'user' || lpad(gs::text, 2, '0'),
+    'nickname' || lpad(gs::text, 2, '0')
 FROM generate_series(1, 10) gs
     RETURNING id
 )

--- a/spring/src/main/resources/static/index.html
+++ b/spring/src/main/resources/static/index.html
@@ -209,6 +209,22 @@
             border-color: #adb5bd;
         }
 
+        /* active 상태에서도 liked 스타일 유지 */
+        .category-card.active .like-btn.liked {
+            background: #4299e1;
+            color: white;
+            border-color: #4299e1;
+        }
+
+        .category-card.active .like-btn.liked:hover {
+            background: #3182ce;
+            border-color: #3182ce;
+        }
+
+        .category-card.active .like-btn.liked .like-count {
+            color: white;
+        }
+
         .like-btn.liked {
             background: #4299e1;
             color: white;
@@ -1220,6 +1236,100 @@
             font-size: 12px;
         }
 
+        /* 사용자 정보 팝업 모달 */
+        .user-info-modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.6);
+            z-index: 10001;
+            justify-content: center;
+            align-items: center;
+            backdrop-filter: blur(4px);
+        }
+
+        .user-info-modal.active {
+            display: flex;
+        }
+
+        .user-info-modal-content {
+            background: white;
+            width: 90%;
+            max-width: 500px;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+            overflow: hidden;
+        }
+
+        .user-info-modal-header {
+            padding: 20px 24px;
+            background: #f8f9fa;
+            border-bottom: 2px solid #e2e8f0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .user-info-modal-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2d3748;
+        }
+
+        .user-info-modal-close {
+            background: none;
+            border: none;
+            font-size: 28px;
+            cursor: pointer;
+            color: #718096;
+            line-height: 1;
+            padding: 0;
+            width: 32px;
+            height: 32px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 4px;
+            transition: all 0.2s ease;
+        }
+
+        .user-info-modal-close:hover {
+            background: #e2e8f0;
+            color: #2d3748;
+        }
+
+        .user-info-modal-body {
+            padding: 24px;
+        }
+
+        .user-info-field {
+            margin-bottom: 20px;
+        }
+
+        .user-info-label {
+            font-size: 12px;
+            font-weight: 600;
+            color: #718096;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 6px;
+        }
+
+        .user-info-value {
+            font-size: 15px;
+            color: #2d3748;
+            line-height: 1.5;
+            word-break: break-word;
+        }
+
+        .user-info-value.empty {
+            color: #a0aec0;
+            font-style: italic;
+        }
+
         /* ========== manage.html 추가 CSS ========== */
 
         /* TIME 테이블 */
@@ -1764,7 +1874,7 @@
             height: 18px;  /* 크기 증가: 14px → 18px */
             cursor: pointer;
             transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-                        box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+            box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
             flex-shrink: 0;
             border-radius: 2px;
             border: 1px solid rgba(0, 0, 0, 0.1);  /* 테두리 추가 */
@@ -2400,7 +2510,7 @@
             min-height: 60px;
             align-items: center;
         }
-    /* 카테고리 카드 액션 버튼 */
+        /* 카테고리 카드 액션 버튼 */
         .category-action-btn {
             min-width: 65px;
         }
@@ -2501,6 +2611,15 @@
                             style="text-align: right; padding: 5px 10px 5px 0; font-size: 14px;">Username:
                         </td>
                         <td style="padding: 5px 0;"><input id="signupUsername" required
+                                                           style="padding: 5px; width: 200px; border: 1px solid #999; font-size: 14px;"
+                                                           type="text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td data-lang-en="Nickname:" data-lang-ko="닉네임:"
+                            style="text-align: right; padding: 5px 10px 5px 0; font-size: 14px;">Nickname:
+                        </td>
+                        <td style="padding: 5px 0;"><input id="signupNickname" required
                                                            style="padding: 5px; width: 200px; border: 1px solid #999; font-size: 14px;"
                                                            type="text">
                         </td>
@@ -3447,7 +3566,7 @@
             username: document.getElementById('signupUsername').value,
             email: document.getElementById('signupEmail').value,
             password: document.getElementById('signupPassword').value,
-            nickname: document.getElementById('signupUsername').value, // nickname 필수
+            nickname: document.getElementById('signupNickname').value,
             title: document.getElementById('signupTitle').value || '',
             description: document.getElementById('signupDescription').value || '',
             birthYear: parseInt(document.getElementById('signupBirthYear').value),
@@ -3601,11 +3720,12 @@
     // 공개 카테고리 로드
     async function loadPublicCategories(isInitial = false) {
         if (isLoading) {
-
+            console.log('[INDEX] Already loading, skipping...');
             return;
         }
 
         isLoading = true;
+        console.log('[INDEX] Starting loadPublicCategories, isInitial:', isInitial);
 
         // 로딩 인디케이터 표시
         const loadingIndicator = document.getElementById('loadingIndicator');
@@ -3620,9 +3740,11 @@
             if (accessToken) {
                 // 로그인 후: /api/category/public/summary (AccessToken 헤더에 포함)
                 url = `${API_BASE}/category/public/summary`;
+                console.log('[INDEX] Using authenticated endpoint (with token)');
             } else {
                 // 로그인 전: /api/category/public/summary/no-token
                 url = `${API_BASE}/category/public/summary/no-token`;
+                console.log('[INDEX] Using public endpoint (no token)');
             }
 
             // 쿼리 파라미터 구성
@@ -3631,29 +3753,39 @@
             // 검색어
             if (currentSearchQuery) {
                 params.append('search', currentSearchQuery);
+                console.log('[INDEX] Search query:', currentSearchQuery);
             }
 
             // 정렬
             params.append('key', currentSortKey);
             params.append('sort', currentSortDirection);
+            console.log('[INDEX] Sort:', currentSortKey, currentSortDirection);
 
             // 페이지네이션 (초기 로드가 아닐 때만)
             if (!isInitial && nextCursor) {
                 params.append('cursor', nextCursor);
+                console.log('[INDEX] Cursor:', nextCursor);
             }
             if (!isInitial && nextIdAfter) {
                 params.append('idAfter', nextIdAfter);
+                console.log('[INDEX] IdAfter:', nextIdAfter);
             }
 
             // 페이지 크기
             params.append('size', '50');
 
             const fullUrl = `${url}?${params.toString()}`;
+            console.log('[INDEX] Full URL:', fullUrl);
 
             const response = await fetchWithCsrf(fullUrl);
+            console.log('[INDEX] Response status:', response.status);
+            console.log('[INDEX] Response ok:', response.ok);
 
             if (response.ok) {
                 const data = await response.json();
+                console.log('[INDEX] Response data:', data);
+                console.log('[INDEX] Contents length:', data.contents ? data.contents.length : 0);
+                console.log('[INDEX] Has next:', data.hasNext);
 
                 // 페이지네이션 정보 업데이트
                 nextCursor = data.nextCursor || null;
@@ -3662,13 +3794,16 @@
 
                 // 새로운 카테고리 추가
                 if (data.contents && Array.isArray(data.contents)) {
+                    console.log('[INDEX] Processing contents array');
                     if (isInitial) {
                         allCategories = data.contents;
                         displayCategories(data.contents, true);
+                        console.log('[INDEX] Initial load complete, categories:', allCategories.length);
                     } else {
                         // 추가 로드: 새로 받은 데이터만 전달
                         allCategories = [...allCategories, ...data.contents];
                         displayCategories(data.contents, false); // 새로 받은 것만!
+                        console.log('[INDEX] Added more categories, total:', allCategories.length);
                     }
 
                     // 스크롤이 생기지 않았으면 추가 로드
@@ -3676,20 +3811,23 @@
                         checkAndLoadMore();
                     }, 100);
                 } else {
+                    console.warn('[INDEX] No contents in response or not an array');
                     if (isInitial) {
                         document.getElementById('categoriesGrid').innerHTML =
                             '<div class="empty-state">공개 카테고리가 없습니다.</div>';
                     }
                 }
             } else {
-
+                const errorText = await response.text();
+                console.error('[INDEX] Failed to load categories:', response.status, errorText);
                 if (isInitial) {
                     document.getElementById('categoriesGrid').innerHTML =
-                        '<div class="empty-state">공개 카테고리를 불러올 수 없습니다.</div>';
+                        `<div class="empty-state">공개 카테고리를 불러올 수 없습니다. (${response.status})</div>`;
                 }
             }
         } catch (error) {
-
+            console.error('[INDEX] Error loading categories:', error);
+            console.error('[INDEX] Error stack:', error.stack);
             if (isInitial) {
                 document.getElementById('categoriesGrid').innerHTML =
                     '<div class="empty-state">오류가 발생했습니다.</div>';
@@ -3705,10 +3843,11 @@
 
     // 카테고리 표시
     function displayCategories(categories, isInitial = true) {
-
+        console.log('[INDEX displayCategories] Called with', categories.length, 'categories, isInitial:', isInitial);
         const grid = document.getElementById('categoriesGrid');
 
         if (!categories || categories.length === 0) {
+            console.log('[INDEX displayCategories] No categories to display');
             if (isInitial) {
                 grid.innerHTML = '<div class="empty-state" data-lang-ko="공개된 카테고리가 없습니다." data-lang-en="No public categories available.">공개된 카테고리가 없습니다.</div>';
                 applyLanguage();
@@ -3716,27 +3855,49 @@
             return;
         }
 
-        const categoriesHtml = categories.map(category => {
+        console.log('[INDEX displayCategories] First category:', categories[0]);
+
+        const categoriesHtml = categories.map((category, index) => {
             // 새로운 API 응답 구조에 맞게 필드 매핑
             const id = category.categoryId || category.id;
             const title = category.categoryTitle || category.title || '제목 없음';
             const description = category.categoryDesc || category.description || '';
             const recordType = category.type || category.recordType;
-            const authorNickname = category.authorNickname || category.email || '익명';
+            const authorNickname = category.authorNickname || category.nickname || '익명';
+            const authorEmail = category.authorEmail || category.email || '';
+            const authorTitle = category.authorTitle || '';
+            const authorDesc = category.authorDesc || '';
             const likeCount = category.likeCount || 0;
             const commentCount = category.commentCount || 0;
             const hasLike = category.hasLike || false;
 
+            console.log(`[INDEX displayCategories] Category ${index}:`, {
+                id, title, recordType, authorNickname, authorEmail, authorTitle, authorDesc, likeCount, commentCount
+            });
+
             // id가 없으면 건너뛰기
             if (!id) {
+                console.warn('[INDEX displayCategories] Skipping category without id:', category);
                 return '';
             }
+
+            // 작성자 정보를 JSON 문자열로 인코딩 (HTML 속성에 안전하게 전달)
+            const authorInfo = JSON.stringify({
+                nickname: authorNickname,
+                email: authorEmail,
+                title: authorTitle,
+                description: authorDesc
+            }).replace(/"/g, '&quot;');
 
             return `
                 <div class="category-card" data-id="${id}" data-type="${recordType}">
                     <div class="category-title">${title}</div>
                     <div class="category-type">${recordType}</div>
-                    <div class="category-meta"><span data-lang-ko="작성자" data-lang-en="Author">작성자</span>: ${authorNickname}</div>
+                    <div class="category-meta">
+                        <span data-lang-ko="작성자" data-lang-en="Author">작성자</span>:
+                        <span style="cursor: pointer; color: #4299e1; text-decoration: underline;"
+                              onclick="showUserInfoDirect(event, '${authorInfo}')">${authorNickname}</span>
+                    </div>
                     <div class="category-actions">
                         <button class="category-action-btn like-btn ${hasLike ? 'liked' : ''}" data-category-id="${id}" onclick="toggleLike(event, '${id}')">
                             <span data-lang-ko="좋아요" data-lang-en="Likes">좋아요</span>
@@ -3750,12 +3911,16 @@
             `;
         }).join('');
 
+        console.log('[INDEX displayCategories] Generated HTML length:', categoriesHtml.length);
+
         if (isInitial) {
             // 초기 로드: 전체 교체
             grid.innerHTML = categoriesHtml;
+            console.log('[INDEX displayCategories] Initial load - replaced grid content');
         } else {
             // 추가 로드: 기존 내용에 추가
             grid.insertAdjacentHTML('beforeend', categoriesHtml);
+            console.log('[INDEX displayCategories] Appended to grid');
         }
 
         // 언어 적용
@@ -3763,7 +3928,9 @@
 
         // 카테고리 클릭 이벤트 (새로 추가된 카드에만)
         const cards = isInitial ? grid.querySelectorAll('.category-card') :
-                                   Array.from(grid.querySelectorAll('.category-card')).slice(-categories.length);
+            Array.from(grid.querySelectorAll('.category-card')).slice(-categories.length);
+
+        console.log('[INDEX displayCategories] Setting up click listeners for', cards.length, 'cards');
 
         cards.forEach(card => {
             // 기존 이벤트 리스너가 없는 경우에만 추가
@@ -5656,6 +5823,42 @@
 
 <!-- 토스트 알림 컨테이너 -->
 <div class="toast-container" id="toastContainer"></div>
+
+<!-- 사용자 정보 팝업 모달 -->
+<div class="user-info-modal" id="userInfoModal">
+    <div class="user-info-modal-content">
+        <div class="user-info-modal-header">
+            <div class="user-info-modal-title" data-lang-en="User Information" data-lang-ko="사용자 정보">사용자 정보</div>
+            <button class="user-info-modal-close" onclick="closeUserInfoModal()">&times;</button>
+        </div>
+        <div class="user-info-modal-body">
+            <div class="user-info-field">
+                <div class="user-info-label" data-lang-en="Username" data-lang-ko="사용자명">사용자명</div>
+                <div class="user-info-value" id="userInfoUsername">-</div>
+            </div>
+            <div class="user-info-field">
+                <div class="user-info-label" data-lang-en="Nickname" data-lang-ko="닉네임">닉네임</div>
+                <div class="user-info-value" id="userInfoNickname">-</div>
+            </div>
+            <div class="user-info-field">
+                <div class="user-info-label" data-lang-en="Email" data-lang-ko="이메일">이메일</div>
+                <div class="user-info-value" id="userInfoEmail">-</div>
+            </div>
+            <div class="user-info-field">
+                <div class="user-info-label" data-lang-en="Title" data-lang-ko="직함">직함</div>
+                <div class="user-info-value" id="userInfoTitle">-</div>
+            </div>
+            <div class="user-info-field">
+                <div class="user-info-label" data-lang-en="Description" data-lang-ko="소개">소개</div>
+                <div class="user-info-value" id="userInfoDescription">-</div>
+            </div>
+            <div class="user-info-field">
+                <div class="user-info-label" data-lang-en="Birth Date" data-lang-ko="생년월일">생년월일</div>
+                <div class="user-info-value" id="userInfoBirthDate">-</div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- 알림 목록 모달 -->
 <div class="notification-modal" id="notificationModal">
@@ -9227,6 +9430,77 @@
     window.addEventListener('pagehide', () => {
         isPageUnloading = true;
         disconnectSSE();
+    });
+
+    // ==================== 사용자 정보 팝업 관련 함수 ====================
+
+    // 사용자 정보 표시
+    // 사용자 정보 표시 (이미 받은 데이터 사용)
+    function showUserInfoDirect(event, authorInfoJson) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        try {
+            // HTML 엔티티 디코드 및 JSON 파싱
+            const authorInfo = JSON.parse(authorInfoJson.replace(/&quot;/g, '"'));
+            console.log('[INDEX] Showing user info:', authorInfo);
+
+            // 모달에 정보 채우기
+            document.getElementById('userInfoNickname').textContent = authorInfo.nickname || '-';
+            document.getElementById('userInfoEmail').textContent = authorInfo.email || '-';
+
+            // Username은 숨기기 (API에서 제공하지 않으므로)
+            const usernameField = document.getElementById('userInfoUsername').parentElement;
+            usernameField.style.display = 'none';
+
+            // Title 처리
+            const titleElement = document.getElementById('userInfoTitle');
+            if (authorInfo.title) {
+                titleElement.textContent = authorInfo.title;
+                titleElement.classList.remove('empty');
+            } else {
+                titleElement.textContent = currentLang === 'ko' ? '설정되지 않음' : 'Not set';
+                titleElement.classList.add('empty');
+            }
+
+            // Description 처리
+            const descElement = document.getElementById('userInfoDescription');
+            if (authorInfo.description) {
+                descElement.textContent = authorInfo.description;
+                descElement.classList.remove('empty');
+            } else {
+                descElement.textContent = currentLang === 'ko' ? '설정되지 않음' : 'Not set';
+                descElement.classList.add('empty');
+            }
+
+            // Birth Date는 숨기기 (API에서 제공하지 않으므로)
+            const birthField = document.getElementById('userInfoBirthDate').parentElement;
+            birthField.style.display = 'none';
+
+            // 모달 열기
+            document.getElementById('userInfoModal').classList.add('active');
+        } catch (error) {
+            console.error('Error parsing author info:', error);
+            alert(currentLang === 'ko' ? '사용자 정보를 표시할 수 없습니다.' : 'Failed to display user information.');
+        }
+    }
+
+    // 사용자 정보 모달 닫기
+    function closeUserInfoModal() {
+        document.getElementById('userInfoModal').classList.remove('active');
+
+        // 숨긴 필드들 다시 표시 (다음 사용을 위해)
+        const usernameField = document.getElementById('userInfoUsername').parentElement;
+        const birthField = document.getElementById('userInfoBirthDate').parentElement;
+        usernameField.style.display = '';
+        birthField.style.display = '';
+    }
+
+    // 모달 외부 클릭 시 닫기
+    document.getElementById('userInfoModal').addEventListener('click', (e) => {
+        if (e.target.id === 'userInfoModal') {
+            closeUserInfoModal();
+        }
     });
 
 </script>

--- a/spring/src/main/resources/static/insert.html
+++ b/spring/src/main/resources/static/insert.html
@@ -797,7 +797,7 @@
             min-width: 20px;
             text-align: center;
         }
-/* 토스트 알림 컨테이너 */
+        /* 토스트 알림 컨테이너 */
         .toast-container {
             position: fixed;
             bottom: 20px;
@@ -1306,7 +1306,7 @@
             min-height: 60px;
             align-items: center;
         }
-    /* 카테고리 카드 액션 버튼 */
+        /* 카테고리 카드 액션 버튼 */
         .category-action-btn {
             min-width: 65px;
         }
@@ -1329,7 +1329,7 @@
 <body>
 <!-- 로그인 섹션 -->
 <div id="loginSection"
-     style="display: block; position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1000;">
+     style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1000;">
     <div class="simple-auth-container">
         <div class="simple-auth-box">
             <div style="text-align: left; margin-bottom: 10px;">
@@ -1391,6 +1391,13 @@
                     <tr>
                         <td style="text-align: right; padding: 5px 10px 5px 0; font-size: 13px;">Username:</td>
                         <td style="padding: 5px 0;"><input id="signupUsername" required
+                                                           style="padding: 6px; width: 200px; border: 1px solid #ccc; font-size: 13px;"
+                                                           type="text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 5px 10px 5px 0; font-size: 13px;">Nickname:</td>
+                        <td style="padding: 5px 0;"><input id="signupNickname" required
                                                            style="padding: 6px; width: 200px; border: 1px solid #ccc; font-size: 13px;"
                                                            type="text">
                         </td>
@@ -1801,21 +1808,17 @@
         }
     }
 
-    // AccessToken 저장
+    // AccessToken 저장 (메모리에만 저장 - 보안상 localStorage 사용 안 함)
     function setAccessToken(token) {
         accessToken = token;
-        localStorage.setItem('accessToken', token);
     }
 
     // AccessToken 가져오기
     function getAccessToken() {
-        if (!accessToken) {
-            accessToken = localStorage.getItem('accessToken');
-        }
         return accessToken;
     }
 
-    // AccessToken 갱신
+    // AccessToken 갱신 (RefreshToken 쿠키로 새 AccessToken 발급)
     async function refreshAccessToken() {
         try {
             if (!csrfToken) {
@@ -1824,15 +1827,7 @@
 
             const headers = { 'Content-Type': 'application/json' };
 
-            // 기존 AccessToken이 있으면 헤더에 추가
-            const token = getAccessToken();
-            if (token) {
-                headers['Authorization'] = `Bearer ${token}`;
-                console.log('[INSERT REFRESH] Sending AccessToken:', token.substring(0, 20) + '...');
-            } else {
-                console.log('[INSERT REFRESH] No AccessToken - using RefreshToken cookie only');
-            }
-
+            // CSRF 토큰 추가
             if (csrfToken) {
                 headers['X-XSRF-TOKEN'] = csrfToken;
             }
@@ -1848,23 +1843,23 @@
                 const newToken = data.accessToken || data.access_token || data.token;
                 if (newToken && typeof newToken === 'string') {
                     setAccessToken(newToken);
-                    console.log('[INSERT REFRESH] New AccessToken received:', newToken.substring(0, 20) + '...');
                     return true;
                 }
             }
             return false;
         } catch (error) {
-            console.error('[INSERT REFRESH] Token refresh failed:', error);
             return false;
         }
     }
 
     // 인증된 fetch 요청
     async function authFetch(url, options = {}) {
-        const token = getAccessToken();
-        console.log('[INSERT authFetch] URL:', url);
-        console.log('[INSERT authFetch] AccessToken:', token ? `${token.substring(0, 20)}...` : 'NULL');
+        // CSRF 토큰이 없으면 먼저 가져오기
+        if (!csrfToken) {
+            csrfToken = getCsrfToken();
+        }
 
+        // 기본 옵션 설정
         const defaultOptions = {
             credentials: 'include',
             headers: {
@@ -1873,28 +1868,19 @@
             }
         };
 
-        if (token) {
-            defaultOptions.headers['Authorization'] = `Bearer ${token}`;
-            console.log('[INSERT authFetch] Authorization header set:', `Bearer ${token.substring(0, 20)}...`);
-        } else {
-            console.log('[INSERT authFetch] No token - Authorization header not set');
+        // AccessToken이 있으면 Authorization 헤더 추가
+        if (accessToken) {
+            defaultOptions.headers['Authorization'] = `Bearer ${accessToken}`;
         }
 
+        // POST, PUT, DELETE, PATCH 요청에 CSRF 토큰 추가
         if (options.method && ['POST', 'PUT', 'DELETE', 'PATCH'].includes(options.method.toUpperCase())) {
-            if (!csrfToken) {
-                csrfToken = getCsrfToken();
-                console.log('[INSERT authFetch] Got CSRF token from cookie:', csrfToken ? csrfToken.substring(0, 20) + '...' : 'NULL');
-            } else {
-                console.log('[INSERT authFetch] Using existing CSRF token:', csrfToken.substring(0, 20) + '...');
-            }
             if (csrfToken) {
                 defaultOptions.headers['X-XSRF-TOKEN'] = csrfToken;
-                console.log('[INSERT authFetch] X-XSRF-TOKEN header set');
-            } else {
-                console.error('[INSERT authFetch] No CSRF token available!');
             }
         }
 
+        // 옵션 병합
         const finalOptions = {
             ...defaultOptions,
             ...options,
@@ -1904,15 +1890,50 @@
             }
         };
 
-        console.log('[INSERT authFetch] Final headers:', finalOptions.headers);
-        return await fetch(url, finalOptions);
+        const response = await fetch(url, finalOptions);
+
+        // 응답 헤더에서 새로운 CSRF 토큰 확인 및 자동 업데이트
+        const responseCsrfToken = response.headers.get('X-CSRF-TOKEN');
+        if (responseCsrfToken) {
+            csrfToken = responseCsrfToken;
+        } else {
+            // 응답 헤더에 없으면 쿠키에서 다시 읽기
+            const cookieToken = getCsrfToken();
+            if (cookieToken && cookieToken !== csrfToken) {
+                csrfToken = cookieToken;
+            }
+        }
+
+        // 401 에러 시 토큰 갱신 시도
+        if (response.status === 401) {
+            const refreshed = await refreshAccessToken();
+            if (refreshed && accessToken) {
+                // 토큰 갱신 성공 - 재시도
+                finalOptions.headers['Authorization'] = `Bearer ${accessToken}`;
+                return await fetch(url, finalOptions);
+            } else {
+                // 토큰 갱신 실패 - RefreshToken 만료 또는 없음
+                currentUser = null;
+                accessToken = null;
+                location.href = location.pathname; // 현재 페이지 새로고침
+                throw new Error('Authentication required');
+            }
+        }
+
+        // 403 에러 시 CSRF 토큰 갱신 후 재시도
+        if (response.status === 403) {
+            await initCsrfToken();
+            if (csrfToken) {
+                finalOptions.headers['X-XSRF-TOKEN'] = csrfToken;
+                return await fetch(url, finalOptions);
+            }
+        }
+
+        return response;
     }
 
-    // 사용자 정보 설정 (로그인 시 이미 인증됨)
+    // 인증 상태 확인
     function checkAuth() {
-        console.log('[INSERT] Auth already verified by login');
-        // 로그인이 성공했으면 이미 인증된 상태
-        // accessToken이 있으면 인증된 것으로 간주
         return !!accessToken;
     }
 
@@ -2970,15 +2991,15 @@
     // 페이지 언로드 전 SSE 연결 종료
     window.addEventListener('beforeunload', () => {
         disconnectSSE();
-                console.log('[INSERT LOGIN] SSE connected');
+        console.log('[INSERT LOGIN] SSE connected');
     });
 
     // 페이지 숨김 시 연결 종료 (모바일/탭 전환 대응)
     document.addEventListener('visibilitychange', () => {
         if (document.hidden) {
             disconnectSSE();
-                console.log('[INSERT LOGIN] SSE connected');
-        } else if (!isPageUnloading && localStorage.getItem('accessToken')) {
+            console.log('[INSERT LOGIN] SSE connected');
+        } else if (!isPageUnloading && accessToken) {
             // 페이지가 다시 보일 때만 재연결
             const mainSection = document.getElementById('mainSection');
             if (mainSection && mainSection.style.display !== 'none') {
@@ -2991,7 +3012,7 @@
     // 페이지 숨김 이벤트 (iOS Safari 대응)
     window.addEventListener('pagehide', () => {
         disconnectSSE();
-                console.log('[INSERT LOGIN] SSE connected');
+        console.log('[INSERT LOGIN] SSE connected');
     });
 
     // 화면 전환 함수들
@@ -3311,7 +3332,7 @@
             username: document.getElementById('signupUsername').value,
             email: document.getElementById('signupEmail').value,
             password: document.getElementById('signupPassword').value,
-            nickname: document.getElementById('signupUsername').value,
+            nickname: document.getElementById('signupNickname').value,
             title: document.getElementById('signupTitle').value || '',
             description: document.getElementById('signupDescription').value || '',
             birthYear: parseInt(document.getElementById('signupBirthYear').value),

--- a/spring/src/main/resources/static/manage.html
+++ b/spring/src/main/resources/static/manage.html
@@ -1127,7 +1127,7 @@
             height: 14px;
             cursor: pointer;
             transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-                        box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+            box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
             flex-shrink: 0;
             border-radius: 2px;
         }
@@ -3208,7 +3208,7 @@
             min-height: 60px;
             align-items: center;
         }
-    /* 카테고리 카드 액션 버튼 */
+        /* 카테고리 카드 액션 버튼 */
         .category-action-btn {
             min-width: 65px;
         }
@@ -3227,7 +3227,7 @@
 <body>
 <!-- 로그인 섹션 -->
 <div id="loginSection"
-     style="display: block; position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1000;">
+     style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1000;">
     <div class="simple-auth-container">
         <div class="simple-auth-box">
             <div style="text-align: left; margin-bottom: 10px;">
@@ -3288,6 +3288,13 @@
                     <tr>
                         <td style="text-align: right; padding: 5px 10px 5px 0; font-size: 14px;">Username:</td>
                         <td style="padding: 5px 0;"><input id="signupUsername" required
+                                                           style="padding: 5px; width: 200px; border: 1px solid #999; font-size: 14px;"
+                                                           type="text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 5px 10px 5px 0; font-size: 14px;">Nickname:</td>
+                        <td style="padding: 5px 0;"><input id="signupNickname" required
                                                            style="padding: 5px; width: 200px; border: 1px solid #999; font-size: 14px;"
                                                            type="text">
                         </td>
@@ -3429,6 +3436,7 @@
         <a class="btn" data-lang-en="Home" data-lang-ko="홈" href="index.html">홈</a>
         <a class="btn" data-lang-en="Insert Data" data-lang-ko="데이터 입력" href="insert.html">데이터 입력</a>
         <a class="btn" data-lang-en="My Page" data-lang-ko="내 관리" href="manage.html">내 관리</a>
+        <button class="btn" data-lang-en="Edit Profile" data-lang-ko="회원정보 수정" id="editProfileBtn" onclick="openEditProfileModal()">회원정보 수정</button>
         <button class="notification-bell" id="notificationBell" onclick="toggleNotificationModal()"><span
                 data-lang-en="Alerts" data-lang-ko="알림">알림</span><span class="notification-badge" id="notificationBadge"
                                                                        style="display: none;">0</span>
@@ -3483,33 +3491,6 @@
                 <button class="btn" data-lang-en="Delete" data-lang-ko="삭제" onclick="deleteRecord()" type="button">삭제
                 </button>
                 <button class="btn" data-lang-en="Cancel" data-lang-ko="취소" onclick="closeEditModal()" type="button">
-                    취소
-                </button>
-            </div>
-        </form>
-    </div>
-</div>
-
-<!-- 프로필 수정 모달 -->
-<div class="modal" id="profileModal">
-    <div class="modal-content">
-        <div class="modal-header">
-            <div class="modal-title" data-lang-en="Edit Profile" data-lang-ko="프로필 수정">프로필 수정</div>
-            <button class="modal-close" onclick="closeProfileModal()">×</button>
-        </div>
-        <div id="profileModalError"></div>
-        <form id="profileForm">
-            <div class="form-group">
-                <label data-lang-en="Title" data-lang-ko="타이틀" for="profileTitle">타이틀</label>
-                <input id="profileTitle" placeholder="예: Hi." type="text">
-            </div>
-            <div class="form-group">
-                <label data-lang-en="Description" data-lang-ko="설명" for="profileDescription">설명</label>
-                <textarea id="profileDescription" placeholder="간단한 소개를 입력하세요"></textarea>
-            </div>
-            <div class="modal-actions">
-                <button class="btn btn-primary" data-lang-en="Save" data-lang-ko="저장" type="submit">저장</button>
-                <button class="btn" data-lang-en="Cancel" data-lang-ko="취소" onclick="closeProfileModal()" type="button">
                     취소
                 </button>
             </div>
@@ -4818,6 +4799,7 @@
             username: document.getElementById('signupUsername').value,
             email: document.getElementById('signupEmail').value,
             password: document.getElementById('signupPassword').value,
+            nickname: document.getElementById('signupNickname').value,
             title: document.getElementById('signupTitle').value || '',
             description: document.getElementById('signupDescription').value || '',
             birthYear: parseInt(birthYear) || new Date().getFullYear(),
@@ -8456,79 +8438,6 @@
         document.getElementById('loginSection').style.display = 'block';
     }
 
-    // 프로필 수정 모달 열기
-    const editProfileBtn = document.getElementById('editProfileBtn');
-    if (editProfileBtn) {
-        editProfileBtn.addEventListener('click', () => {
-            if (currentUser) {
-                document.getElementById('profileTitle').value = currentUser.title || '';
-                document.getElementById('profileDescription').value = currentUser.description || '';
-                document.getElementById('profileModal').classList.add('active');
-            }
-        });
-    }
-
-    // 프로필 수정 모달 닫기
-    function closeProfileModal() {
-        document.getElementById('profileModal').classList.remove('active');
-        document.getElementById('profileModalError').innerHTML = '';
-    }
-
-    // 프로필 수정 폼 제출
-    document.getElementById('profileForm').addEventListener('submit', async (e) => {
-        e.preventDefault();
-
-        if (!currentUser) return;
-
-        const title = document.getElementById('profileTitle').value;
-        const description = document.getElementById('profileDescription').value;
-
-        const params = new URLSearchParams();
-        params.append('title', title);
-        params.append('description', description);
-
-        try {
-            const response = await authFetch(`${API_BASE}/user?${params.toString()}`, {
-                method: 'PUT'
-            });
-
-            if (response.ok) {
-                // 업데이트된 user 정보 반영
-                currentUser.title = title;
-                currentUser.description = description;
-
-                // UI 업데이트
-                document.getElementById('userGreeting').textContent = title || 'Hi.';
-
-                // description이 없으면 오늘 날짜 표시
-                if (description) {
-                    document.getElementById('userDesc').textContent = description;
-                } else {
-                    const now = new Date();
-                    const year = String(now.getFullYear()).slice(2);
-                    const month = String(now.getMonth() + 1).padStart(2, '0');
-                    const day = String(now.getDate()).padStart(2, '0');
-                    document.getElementById('userDesc').textContent = `${year}.${month}.${day}`;
-                }
-
-                closeProfileModal();
-            } else {
-                showProfileModalError('프로필 수정에 실패했습니다.');
-            }
-        } catch (error) {
-
-            showProfileModalError('프로필 수정 중 오류가 발생했습니다.');
-        }
-    });
-
-    function showProfileModalError(message) {
-        const element = document.getElementById('profileModalError');
-        element.innerHTML = `<div class="error-message">${message}</div>`;
-        setTimeout(() => {
-            element.innerHTML = '';
-        }, 5000);
-    }
-
     function showError(elementId, message) {
         const element = document.getElementById(elementId);
         element.innerHTML = `<div class="error-message">${message}</div>`;
@@ -9105,6 +9014,84 @@
     }
 </script>
 
+<!-- 회원정보 수정 모달 -->
+<div class="notification-modal" id="editProfileModal" style="display: none;">
+    <div class="notification-modal-content" style="max-width: 500px;">
+        <div class="notification-modal-header">
+            <div class="notification-modal-title" data-lang-en="Edit Profile" data-lang-ko="회원정보 수정">회원정보 수정</div>
+            <button class="notification-modal-close" onclick="closeEditProfileModal()" style="background: none; border: none; font-size: 24px; cursor: pointer; color: #666;">&times;</button>
+        </div>
+        <div style="padding: 20px;">
+            <form id="editProfileForm">
+                <table style="width: 100%; border-collapse: collapse;">
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px; width: 120px;">Username:</td>
+                        <td style="padding: 8px 0;"><input id="editUsername" readonly
+                                                           style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; background: #f7fafc; font-size: 14px; border-radius: 6px;"
+                                                           type="text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px;">Nickname:</td>
+                        <td style="padding: 8px 0;"><input id="editNickname" required
+                                                           style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; font-size: 14px; border-radius: 6px;"
+                                                           type="text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px;">Email:</td>
+                        <td style="padding: 8px 0;"><input id="editEmail" readonly
+                                                           style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; background: #f7fafc; font-size: 14px; border-radius: 6px;"
+                                                           type="email">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px;">Title:</td>
+                        <td style="padding: 8px 0;"><input id="editTitle"
+                                                           style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; font-size: 14px; border-radius: 6px;"
+                                                           type="text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px;">Description:</td>
+                        <td style="padding: 8px 0;"><textarea id="editDescription"
+                                                              style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; font-size: 14px; border-radius: 6px; min-height: 80px; resize: vertical; font-family: inherit;"></textarea>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px;">Birth Year:</td>
+                        <td style="padding: 8px 0;"><input id="editBirthYear" readonly
+                                                           style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; background: #f7fafc; font-size: 14px; border-radius: 6px;"
+                                                           type="number">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px;">Birth Month:</td>
+                        <td style="padding: 8px 0;"><input id="editBirthMonth" readonly
+                                                           style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; background: #f7fafc; font-size: 14px; border-radius: 6px;"
+                                                           type="number">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: right; padding: 8px 12px 8px 0; font-size: 14px;">Birth Day:</td>
+                        <td style="padding: 8px 0;"><input id="editBirthDay" readonly
+                                                           style="padding: 8px; width: 100%; border: 1px solid #e2e8f0; background: #f7fafc; font-size: 14px; border-radius: 6px;"
+                                                           type="number">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="2" style="padding: 16px 0 0 0;">
+                            <button type="submit" class="btn btn-primary" style="width: 100%; padding: 12px; font-size: 14px;">
+                                <span data-lang-en="Save Changes" data-lang-ko="변경사항 저장">변경사항 저장</span>
+                            </button>
+                        </td>
+                    </tr>
+                </table>
+            </form>
+        </div>
+    </div>
+</div>
+
 <!-- 토스트 알림 컨테이너 -->
 <div class="toast-container" id="toastContainer"></div>
 
@@ -9315,6 +9302,37 @@
             renderNotificationList();
             updateMarkAllReadButton();
         }
+    }
+
+    // 간단한 토스트 알림 (프로필 수정 등에 사용)
+    function showSimpleToast(title, message, type = 'info') {
+        const container = document.getElementById('toastContainer');
+
+        const toast = document.createElement('div');
+        toast.className = `toast-notification ${type.toLowerCase()}`;
+
+        const time = new Date().toLocaleTimeString(currentLang === 'ko' ? 'ko-KR' : 'en-US', {
+            hour: '2-digit',
+            minute: '2-digit'
+        });
+
+        toast.innerHTML = `
+            <div class="toast-title">${title}</div>
+            <div class="toast-message">${message}</div>
+            <div class="toast-time">${time}</div>
+        `;
+
+        toast.onclick = () => {
+            toast.remove();
+        };
+
+        container.appendChild(toast);
+
+        // 3초 후 자동 제거
+        setTimeout(() => {
+            toast.style.animation = 'slideOut 0.3s ease-out';
+            setTimeout(() => toast.remove(), 300);
+        }, 3000);
     }
 
     // 배지 업데이트
@@ -9560,6 +9578,108 @@
     window.addEventListener('pagehide', () => {
         isPageUnloading = true;
         disconnectSSE();
+    });
+
+    // ==================== 회원정보 수정 관련 함수 ====================
+
+    // 회원정보 수정 모달 열기
+    async function openEditProfileModal() {
+        try {
+            const response = await authFetch(`${API_BASE}/user`);
+            if (response.ok) {
+                const userData = await response.json();
+
+                // 폼에 현재 정보 채우기
+                document.getElementById('editUsername').value = userData.username || '';
+                document.getElementById('editNickname').value = userData.nickname || '';
+                document.getElementById('editEmail').value = userData.email || '';
+                document.getElementById('editTitle').value = userData.title || '';
+                document.getElementById('editDescription').value = userData.description || '';
+                document.getElementById('editBirthYear').value = userData.birthYear || '';
+                document.getElementById('editBirthMonth').value = userData.birthMonth || '';
+                document.getElementById('editBirthDay').value = userData.birthDay || '';
+
+                // 모달 표시
+                document.getElementById('editProfileModal').style.display = 'flex';
+            } else {
+                alert(currentLang === 'ko' ? '사용자 정보를 불러올 수 없습니다.' : 'Failed to load user information.');
+            }
+        } catch (error) {
+            console.error('Error loading user data:', error);
+            alert(currentLang === 'ko' ? '사용자 정보를 불러오는 중 오류가 발생했습니다.' : 'Error loading user information.');
+        }
+    }
+
+    // 회원정보 수정 모달 닫기
+    function closeEditProfileModal() {
+        document.getElementById('editProfileModal').style.display = 'none';
+    }
+
+    // 회원정보 수정 폼 제출
+    document.getElementById('editProfileForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const updateData = {
+            nickname: document.getElementById('editNickname').value,
+            title: document.getElementById('editTitle').value || '',
+            description: document.getElementById('editDescription').value || ''
+        };
+
+        try {
+            const params = new URLSearchParams(updateData).toString();
+            const response = await authFetch(`${API_BASE}/user?${params}`, {
+                method: 'PUT'
+            });
+
+            if (response.ok) {
+                // 모달 즉시 닫기
+                closeEditProfileModal();
+
+                // 성공 토스트 알림 표시
+                showSimpleToast(
+                    currentLang === 'ko' ? '프로필 수정 완료' : 'Profile Updated',
+                    currentLang === 'ko' ? '회원정보가 성공적으로 수정되었습니다.' : 'Profile updated successfully.',
+                    'comment'
+                );
+
+                // 1초 후 페이지 새로고침
+                setTimeout(() => {
+                    location.reload();
+                }, 1000);
+            } else {
+                const errorText = await response.text();
+                console.error('Profile update failed:', response.status, errorText);
+
+                // 모달 닫기
+                closeEditProfileModal();
+
+                // 실패 토스트 알림 표시
+                showSimpleToast(
+                    currentLang === 'ko' ? '프로필 수정 실패' : 'Profile Update Failed',
+                    currentLang === 'ko' ? '회원정보 수정에 실패했습니다.' : 'Failed to update profile.',
+                    'like'
+                );
+            }
+        } catch (error) {
+            console.error('Error updating profile:', error);
+
+            // 모달 닫기
+            closeEditProfileModal();
+
+            // 에러 토스트 알림 표시
+            showSimpleToast(
+                currentLang === 'ko' ? '오류 발생' : 'Error',
+                currentLang === 'ko' ? '회원정보 수정 중 오류가 발생했습니다.' : 'Error updating profile.',
+                'like'
+            );
+        }
+    });
+
+    // 모달 외부 클릭 시 닫기
+    document.getElementById('editProfileModal').addEventListener('click', (e) => {
+        if (e.target.id === 'editProfileModal') {
+            closeEditProfileModal();
+        }
     });
 
 


### PR DESCRIPTION
## 관련 이슈
#10 
#7 
#11 
#20

### 변경 사항
- 공개 카테고리 요약 DTO에 작성자 정보 필드 추가  
  - `authorNickname`, `authorTitle`, `authorDesc`, `authorEmail`
- `PublicCategorySummaryResponse.Content`에 작성자 정보 필드 추가
- QueryDSL 조회/매핑 수정
  - select projection에 `user.nickname/title/description/email` 포함
  - 검색 조건에서 `user.username` → `user.nickname` 포함하도록 수정
  - authorNickname 관련 필터/정렬 기준을 `user.username` → `user.nickname`로 변경
- Service 레이어에서 응답 매핑 시 작성자 정보 세팅 추가
- local 환경 JPA ddl-auto: `create` → `update`로 변경
- 더미 데이터 SQL에 users 생성 시 `nickname` 컬럼 추가

### 의도 / 배경
- 공개 카테고리 목록에서 작성자 정보를 더 풍부하게 노출하기 위해 DTO/응답 스펙 확장
- 검색/정렬 기준을 username보다 사용자 노출 값인 nickname 중심으로 맞춤

### 영향 범위
- API 응답 스키마 변경(필드 추가) → 프론트에서 신규 필드 사용 가능
- local DB 스키마 생성 방식 변경(`create` → `update`)으로 재기동 시 데이터 유지 가능

