### PR TITLE
[FEATURE] User find, update profile 추가 

### DIFF
--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'org.postgresql:postgresql'
-
+    implementation 'software.amazon.awssdk:s3:2.31.7'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/spring/src/main/java/com/life/jeonggiju/config/S3Config.java
+++ b/spring/src/main/java/com/life/jeonggiju/config/S3Config.java
@@ -1,0 +1,39 @@
+package com.life.jeonggiju.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Getter
+@Configuration
+@ConditionalOnProperty(name = "storage.type", havingValue = "s3")
+public class S3Config {
+	@Value("${aws.accessKeyId}")
+	private String accessKey;
+
+	@Value("${aws.secretKey}")
+	private String secretKey;
+
+	@Value("${aws.region}")
+	private String region;
+
+	@Value("${aws.bucket}")
+	private String bucket;
+
+	@Bean
+	public S3Client s3Client() {
+		AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+		return S3Client.builder()
+			.region(Region.of(region))
+			.credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+			.build();
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/controller/UserController.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/controller/UserController.java
@@ -1,14 +1,21 @@
 package com.life.jeonggiju.domain.user.controller;
 
+import java.util.UUID;
+
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.life.jeonggiju.domain.user.dto.SignUpRequest;
 import com.life.jeonggiju.domain.user.dto.UpdateUserRequest;
@@ -33,12 +40,16 @@ public class UserController {
 		return ResponseEntity.ok(userService.find(userDetails.getId()));
 	}
 
-	@PutMapping
+	@PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<Void> update(
-		@AuthenticationPrincipal LifeUserDetails userDetails, UpdateUserRequest dto) {
-		userService.update(userDetails.getId(), dto);
+		@AuthenticationPrincipal LifeUserDetails userDetails,
+		@RequestPart(value="image", required = false) MultipartFile image,
+		UpdateUserRequest dto
+	) {
+		userService.update(userDetails.getId(), dto, image);
 		return ResponseEntity.ok().build();
 	}
+
 
 	@DeleteMapping
 	public ResponseEntity<Void> delete(

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/dto/UserFindResponse.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/dto/UserFindResponse.java
@@ -11,6 +11,7 @@ public class UserFindResponse {
 	private String title;
 	private String nickname;
 	private String description;
+	private String profileImageUrl;
 	private int birthYear;
 	private int birthMonth;
 	private int birthDay;

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/entity/User.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/entity/User.java
@@ -44,6 +44,9 @@ public class User {
 	private String password;
 
 	@Column
+	private String profileImageUrl;
+
+	@Column
 	private String title;
 
 	@Column
@@ -85,9 +88,12 @@ public class User {
 	protected User() {
 	}
 
-	public void update(String title, String description, String nickname) {
+	public void update(String title, String description, String nickname, String profileImageUrl) {
 		this.title = title;
 		this.description = description;
 		this.nickname = nickname;
+		if (profileImageUrl != null) {
+			this.profileImageUrl = profileImageUrl;
+		}
 	}
 }

--- a/spring/src/main/java/com/life/jeonggiju/domain/user/service/UserService.java
+++ b/spring/src/main/java/com/life/jeonggiju/domain/user/service/UserService.java
@@ -1,10 +1,12 @@
 package com.life.jeonggiju.domain.user.service;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.life.jeonggiju.domain.user.dto.SignUpRequest;
 import com.life.jeonggiju.domain.user.dto.UpdateUserRequest;
@@ -13,6 +15,8 @@ import com.life.jeonggiju.domain.user.entity.Authority;
 import com.life.jeonggiju.domain.user.entity.User;
 import com.life.jeonggiju.domain.user.exception.UserNotFoundException;
 import com.life.jeonggiju.domain.user.repository.UserRepository;
+import com.life.jeonggiju.storage.BinaryStorage;
+import com.life.jeonggiju.storage.exception.ProfileImageUploadException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +26,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final BinaryStorage binaryStorage;
 
 	@Transactional
 	public void signup(SignUpRequest dto) {
@@ -51,16 +56,28 @@ public class UserService {
 			.title(user.getTitle())
 			.nickname(user.getNickname())
 			.description(user.getDescription())
+			.profileImageUrl(user.getProfileImageUrl())
 			.birthYear(user.getBirthYear())
 			.birthMonth(user.getBirthMonth())
 			.birthDay(user.getBirthDay())
 			.build();
 	}
 	@Transactional
-	public void update(UUID id, UpdateUserRequest dto) {
+	public void update(UUID id, UpdateUserRequest dto, MultipartFile image) {
 		User user = userRepository.findById(id)
 			.orElseThrow(() -> UserNotFoundException.withUserId(id));
-		user.update(dto.getTitle(), dto.getDescription(), dto.getNickName());
+
+		String profileImageUrl = null;
+		if (image != null && !image.isEmpty()) {
+			try {
+				binaryStorage.put(id, image.getBytes());
+				profileImageUrl = binaryStorage.getUrl(id);
+			} catch (IOException e) {
+				throw new ProfileImageUploadException(e);
+			}
+		}
+
+		user.update(dto.getTitle(), dto.getDescription(), dto.getNickName(), profileImageUrl);
 		userRepository.save(user);
 	}
 

--- a/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
+++ b/spring/src/main/java/com/life/jeonggiju/exception/ErrorCode.java
@@ -37,7 +37,9 @@ public enum ErrorCode {
 	TOKEN_GENERATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 생성에 실패했습니다"),
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다"),
 	INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 유효하지 않습니다."),
-	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다.");
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
+
+	PROFILE_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 이미지 업로드에 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/spring/src/main/java/com/life/jeonggiju/storage/BinaryStorage.java
+++ b/spring/src/main/java/com/life/jeonggiju/storage/BinaryStorage.java
@@ -10,4 +10,6 @@ public interface BinaryStorage {
 	InputStream get(UUID userId);
 
 	Boolean exists(UUID userId);
+
+	String getUrl(UUID userId);
 }

--- a/spring/src/main/java/com/life/jeonggiju/storage/BinaryStorage.java
+++ b/spring/src/main/java/com/life/jeonggiju/storage/BinaryStorage.java
@@ -1,0 +1,13 @@
+package com.life.jeonggiju.storage;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.UUID;
+
+public interface BinaryStorage {
+	void put(UUID userId, byte[] data);
+
+	InputStream get(UUID userId);
+
+	Boolean exists(UUID userId);
+}

--- a/spring/src/main/java/com/life/jeonggiju/storage/S3BinaryStorage.java
+++ b/spring/src/main/java/com/life/jeonggiju/storage/S3BinaryStorage.java
@@ -1,0 +1,55 @@
+package com.life.jeonggiju.storage;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.life.jeonggiju.config.S3Config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "storage.type", havingValue = "s3")
+public class S3BinaryStorage implements BinaryStorage {
+
+	private final S3Config config;
+	private final S3Client s3;
+	private static final String PATH = "profile/";
+
+	@Override
+	public void put(UUID userId, byte[] data) {
+		String key = PATH + "/" +  userId;
+
+		s3.putObject(b -> b.bucket(config.getBucket())
+			.key(key), RequestBody.fromBytes(data));
+	}
+
+	@Override
+	public InputStream get(UUID userId) {
+		String key = PATH + "/" +  userId;
+
+		return s3.getObject(b -> b.bucket(config.getBucket())
+			.key(key));
+	}
+
+	@Override
+	public Boolean exists(UUID userId) {
+		String key = PATH + "/" +  userId;
+
+		HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+			.bucket(config.getBucket())
+			.key(key)
+			.build();
+
+		s3.headObject(headObjectRequest);
+		return true;
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/storage/S3BinaryStorage.java
+++ b/spring/src/main/java/com/life/jeonggiju/storage/S3BinaryStorage.java
@@ -52,4 +52,11 @@ public class S3BinaryStorage implements BinaryStorage {
 		s3.headObject(headObjectRequest);
 		return true;
 	}
+
+	@Override
+	public String getUrl(UUID userId) {
+		String key = PATH + "/" + userId;
+		return String.format("https://%s.s3.%s.amazonaws.com/%s",
+			config.getBucket(), config.getRegion(), key);
+	}
 }

--- a/spring/src/main/java/com/life/jeonggiju/storage/exception/ProfileImageUploadException.java
+++ b/spring/src/main/java/com/life/jeonggiju/storage/exception/ProfileImageUploadException.java
@@ -1,0 +1,9 @@
+package com.life.jeonggiju.storage.exception;
+
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class ProfileImageUploadException extends StorageException {
+	public ProfileImageUploadException(Throwable cause) {
+		super(ErrorCode.PROFILE_IMAGE_UPLOAD_FAILED, cause);
+	}
+}

--- a/spring/src/main/java/com/life/jeonggiju/storage/exception/StorageException.java
+++ b/spring/src/main/java/com/life/jeonggiju/storage/exception/StorageException.java
@@ -1,0 +1,14 @@
+package com.life.jeonggiju.storage.exception;
+
+import com.life.jeonggiju.exception.BaseException;
+import com.life.jeonggiju.exception.ErrorCode;
+
+public class StorageException extends BaseException {
+	public StorageException(ErrorCode code) {
+		super(code);
+	}
+
+	public StorageException(ErrorCode code, Throwable cause) {
+		super(code, cause);
+	}
+}

--- a/spring/src/main/resources/application-dev.yml
+++ b/spring/src/main/resources/application-dev.yml
@@ -14,3 +14,5 @@ logging:
     org.springframework.security: debug
     org.springdoc: debug
 
+storage:
+  type: file

--- a/spring/src/main/resources/application-local.yml
+++ b/spring/src/main/resources/application-local.yml
@@ -15,3 +15,6 @@ logging:
     org.springframework.security: off
     org.springdoc: off
 
+storage:
+  type: file
+

--- a/spring/src/main/resources/application-local.yml
+++ b/spring/src/main/resources/application-local.yml
@@ -16,5 +16,5 @@ logging:
     org.springdoc: off
 
 storage:
-  type: file
+  type: s3
 

--- a/spring/src/main/resources/application-prod.yml
+++ b/spring/src/main/resources/application-prod.yml
@@ -9,3 +9,7 @@ spring:
     hibernate:
       ddl-auto: update
     open-in-view: false
+
+
+storage:
+  type: s3

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -37,3 +37,8 @@ init:
     email: ${INIT_USER_EMAIL}
     password: ${INIT_USER_PASSWORD}
 
+aws:
+  accessKeyId: ${AWS_S3_ACCESS_KEY}
+  secretKey: ${AWS_S3_SECRET_KEY}
+  region: ${AWS_S3_REGION}
+  bucket: ${AWS_S3_BUCKET}


### PR DESCRIPTION
## PR 개요
사용자 프로필 이미지 업로드를 위해 S3 기반 스토리지 구조를 추가하고  
사용자 정보 수정 API를 multipart/form-data 형태로 확장했습니다.

## 변경 사항
- S3 BinaryStorage 인터페이스 및 구현체 추가
- S3 설정 분리 (`S3Config`)
- 사용자 프로필 이미지 업로드 및 URL 저장 기능 추가
- 사용자 수정 API에 이미지 업로드 지원
- 프로필 이미지 업로드 실패 예외 처리 추가
- 환경별 스토리지 설정 분리 (dev/file, local·prod/s3)

## 영향 범위
- 사용자 정보 수정 API
- User 도메인
- 스토리지 설정 및 인프라

## 테스트
- 사용자 정보 수정 정상 동작
- 프로필 이미지 업로드 및 URL 저장 확인
